### PR TITLE
Improve line length settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,12 +4,19 @@
     "files.trimTrailingWhitespace": true,
     "editor.insertSpaces": true,
     "editor.tabCompletion": "on",
-    "editor.wordWrap": "wordWrapColumn",
-    "editor.wrappingIndent": "same",
-    "editor.wordWrapColumn": 100,
+
+    // Default for any filetype
     "editor.rulers": [
         100
     ],
+
+    // Python Settings
+    "[python]": {
+        // In python using 80 characters per line is the standard.
+        "editor.rulers": [
+            79
+        ],
+    },
 
     // RST Settings
     "[restructuredtext]": {


### PR DESCRIPTION
Currently "mandatory wrapping" is configured in the project settings, which is not what everyone wants.

Example: It took me a surprisingly long amount of time to understand a line of code, because it looked like two lines. I've not used wrapping in the last 10 years... or ever.

At the same time let's add a python ruler for 80 characters, since it's the de-facto-standard. Not only de-facto, it is the standard. See PEP-8.