### PR TITLE
git: update gitlint documentation

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -6,16 +6,17 @@
 #   T4: title-hard-tab
 #   T5: title-must-not-contain-word (disabled)
 #   T6: title-leading-whitespace
-#   T7: title-match-regex (disabled)
-#   B1: body-max-line-length
+#   T7: title-match-regex
+#   B1: body-max-line-length (disabled)
 #   B2: body-trailing-whitespace
 #   B3: body-hard-tab
 #   B4: body-first-line-empty
 #   B5: body-min-length (disabled)
-#   B6: body-is-missing (disabled)
+#   B6: body-is-missing
 #   B7: body-changed-file-mention (disabled)
 #
-# See http://jorisroovers.github.io/gitlint/rules/ for a full description.
+# See http://jorisroovers.github.io/gitlint/rules/ for a full description of the rules.
+# See https://eclipse-score.github.io/score/process/guidance/git/index.html for our commit message guidelines.
 
 # Ignore some default rules and enable regex style searching
 [general]


### PR DESCRIPTION
The documentation of enabled/disabled rules was a little off. And I was wondering why a body is required, until I found the commit message guidelines, so it seems to make sense to add that link.