### PR TITLE
docs: add recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,2 +1,12 @@
 {
+    "recommendations": [
+        // Editing *.drawio.svg files directly in VS Code
+        "hediet.vscode-drawio",
+
+        // Some convenient extensions for editing reStructuredText files
+        "lextudio.restructuredtext",
+
+        // Linting and live preview for score docs
+        "swyddfa.esbonio"
+    ]
 }


### PR DESCRIPTION
This adds drawio, rst and esbonio extensions. As those three are quite typically useful when editing documentation.
