### PR TITLE
docs: upload always

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           bazel build //docs:github-pages && cp bazel-bin/docs/github-pages.tar .
       - name: Upload artifact for job analysis
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4.4.0
         with:
           name: github-pages-${{ github.sha }}
@@ -73,3 +72,5 @@ jobs:
         # This is only a short-term solution, until we can change the repository settings.
         if: ${{ steps.pages-deployment.outcome == 'failure' && github.event_name == 'push' && github.ref_name == 'main' }}
         uses: actions/deploy-pages@v4.0.5
+        with:
+          artifact_name: github-pages-${{ github.sha }}


### PR DESCRIPTION
And use correct artefact name when deploying (fallback step).