### PR TITLE
IDE: Support Codespaces

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,16 @@
+# One devcontainer?
+In the main repository eclipse-score/score the focus is on documentation, therefore the devcontainer
+is specifically tailored to that purpose. To simplify the setup, only one devcontainer is used,
+for both documentation and development of documentation tooling.
+
+In other eclipse-score repositories, the situation is different and either a combined devcontainer
+or multiple devcontainers is more appropriate.
+
+# Why is Python included?
+Unfortunately multiple python related bazel targets rely on the system python installation.
+
+`py_library` and `py_binary` targets are prominent examples, however they can trivially
+be fixed by using `aspect_rules_py` instead of `rules_python`. Bug-report: https://github.com/bazelbuild/rules_python/issues/691
+
+
+Others are not as easy to work around, e.g. `format.fix`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,17 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/base:1.2-ubuntu-24.04",
+	"image": "mcr.microsoft.com/devcontainers/python:1.2-3.12",
 	"features": {
 		"ghcr.io/devcontainers-community/features/bazel:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"usernamehw.errorlens",
+				"hediet.vscode-drawio",
+				"swyddfa.esbonio",
+				"lextudio.restructuredtext"
+			]
+		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:1.2-ubuntu-24.04",
+	"features": {
+		"ghcr.io/devcontainers-community/features/bazel:1": {}
+	}
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,9 @@
         "lextudio.restructuredtext",
 
         // Linting and live preview for score docs
-        "swyddfa.esbonio"
+        "swyddfa.esbonio",
+
+        // ErrorLens highlights errors and warnings in your code / docs
+        "usernamehw.errorlens",
     ]
 }

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -37,11 +37,10 @@
 #
 # For user-facing documentation, refer to `/README.md`.
 
-load("@aspect_rules_py//py:defs.bzl", "py_venv")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library", "py_venv")
 load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@aspect_rules_py//py:defs.bzl", "py_library", "py_binary")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -41,7 +41,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_venv")
 load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_binary")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 

--- a/docs/_tooling/sphinx_extensions/BUILD
+++ b/docs/_tooling/sphinx_extensions/BUILD
@@ -10,8 +10,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
 load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 

--- a/docs/_tooling/sphinx_extensions/BUILD
+++ b/docs/_tooling/sphinx_extensions/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@pip_sphinx//:requirements.bzl", "all_requirements", "requirement")
-load("@rules_python//python:defs.bzl", "py_library")
+load("@aspect_rules_py//py:defs.bzl", "py_library")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
 


### PR DESCRIPTION
As described in the linked issue, this switches py_binary and py_library to aspect_rules_py. This way there is no dependency to the system python executable.

closes #178 