### PR TITLE
gitlint: Add git hints for gitlint warnings

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -31,4 +31,12 @@ runs:
       git config --global --add safe.directory /github/workspace && \
       git fetch origin +refs/heads/main:refs/remotes/origin/main && \
       git fetch origin +refs/pull/${{ inputs.pr-number }}/head && \
-      gitlint --commits origin/main..HEAD
+      if ! gitlint --commits origin/main..HEAD; then \
+        echo -e "\nWARNING: Your commit message does not follow the required format." && \
+        echo "Formatting rules: https://eclipse-score.github.io/score/process/guidance/git/index.html" && \
+        echo -e "To fix your commit message, run:\n" && \
+        echo " git commit --amend" && \
+        echo "Then update your commit (fix gitlint warnings). Finally, force-push:" && \
+        echo " git push --force-with-lease" && \
+        exit 1; \
+      fi


### PR DESCRIPTION
# Improvement

## Description

Gitlint action will provide information on how to use git to solve commit message warnings.

## Related ticket


related [#210 ] (improvement ticket)