### PR TITLE
Aymen soussi 01 adapt checks

### DIFF
--- a/docs/_tooling/sphinx_extensions/sphinx_extensions/check_options.py
+++ b/docs/_tooling/sphinx_extensions/sphinx_extensions/check_options.py
@@ -43,7 +43,9 @@ def check_options(
     Returns 'True' if an option is not present or a value violates its pattern
     """
 
-    required_options = get_need_type(needs_types, need["type"]).get("req_opt", None)
+    need_options = get_need_type(needs_types, need["type"])
+    required_options: list[tuple[str, str]] = need_options.get("req_opt", [])
+    optional_options: list[tuple[str, str]] = need_options.get("opt_opt", [])
 
     if required_options is None:
         msg = f'Need: {need["id"]} with type {need["type"]}: no type info defined for semantic check.'
@@ -52,7 +54,6 @@ def check_options(
 
     result = False
     for option, pattern in required_options:
-        regex = re.compile(pattern)
         values = need.get(option, None)
 
         if values is None or values in [[], ""]:
@@ -67,10 +68,89 @@ def check_options(
 
         for value in values:
             assert type(value) is str
+            regex = re.compile(pattern)
 
             if not regex.match(value):
-                msg = f'Need: {need["id"]} option `{option}` with value `{value}` does not follow pattern `{pattern}`.'
+                msg = f'Need: {need["id"]} required option `{option}` with value `{value}` does not follow pattern `{pattern}`.'
                 log_custom_warning(need, log, msg)
                 result = True
 
+    if optional_options:
+        for option, pattern in optional_options:
+            values = need.get(option, None)
+
+            if values is None or values in [[], ""]:  # Skip if no values
+                continue
+
+            # Normalize values, which can be a list or a string, to a list of strings
+            if not isinstance(values, list):
+                values = [values]
+
+            for value in values:
+                assert isinstance(value, str)
+                regex = re.compile(pattern)  # Compile regex only if a value exists
+
+                if not regex.match(value):
+                    msg = f'Need: {need["id"]} optional option `{option}` with value `{value}` does not follow pattern `{pattern}`.'
+                    log_custom_warning(need, log, msg)
+                    result = True
+
     return result
+
+
+def check_extra_options(
+    need: NeedsInfoType,
+    log: SphinxLoggerAdapter,
+    needs_types=production_needs_types,
+) -> bool:
+    """
+    This function checks if the user specified attributes in the need which are not defined for this element in the metamodel or by default system attributes.
+    ---
+    Returns 'True' if one of more extra option exist
+    """
+
+    need_options = get_need_type(needs_types, need["type"])
+    required_options: list[tuple[str, str]] = need_options.get("req_opt", [])
+    optional_options: list[tuple[str, str]] = need_options.get("opt_opt", [])
+
+    allowed_options = (
+        [key for key, _ in required_options]
+        + [key for key, _ in optional_options]
+        # list of default system attributes to ignore
+        + [
+            "target_id",
+            "docname",
+            "lineno",
+            "type",
+            "lineno_content",
+            "doctype",
+            "content",
+            "type_name",
+            "type_color",
+            "type_style",
+            "title",
+            "full_title",
+            "layout",
+            "id_parent",
+            "id_complete",
+            "external_css",
+            "sections",
+            "section_name",
+        ]
+    )
+
+    extra_options = [
+        option
+        for option in list(need.keys())
+        if option not in allowed_options
+        and need[option] not in [None, {}, "", []]
+        and not option.endswith("_back")
+    ]
+
+    if extra_options:
+        extra_options_str = ", ".join(f"`{option}`" for option in extra_options)
+        msg = f'Need: {need["id"]} have these extra options: {extra_options_str}.'
+        log_custom_warning(need, log, msg)
+        return True
+
+    return False

--- a/docs/_tooling/sphinx_extensions/sphinx_extensions/checks.py
+++ b/docs/_tooling/sphinx_extensions/sphinx_extensions/checks.py
@@ -10,8 +10,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-from sphinx_needs.api.configuration import add_warning
 from sphinx.application import Sphinx
+from sphinx_needs.api.configuration import add_warning
+
+from docs._tooling.sphinx_extensions.sphinx_extensions.check_options import (
+    check_extra_options,
+    check_options,
+)
 from docs._tooling.sphinx_extensions.sphinx_extensions.requirements.checks.id import (
     check_id_title_part,
 )
@@ -21,10 +26,6 @@ from docs._tooling.sphinx_extensions.sphinx_extensions.requirements.checks.trace
     check_linkage_safety,
     check_linkage_status,
     get_all_needs,
-)
-
-from docs._tooling.sphinx_extensions.sphinx_extensions.check_options import (
-    check_options,
 )
 
 
@@ -40,5 +41,6 @@ def add_warnings(app: Sphinx):
         app, "G_Req_Traceability_Check_Linkage_Status_Check", check_linkage_status
     )
     add_warning(app, "G_Options", check_options)
+    add_warning(app, "G_Extra_Options", check_extra_options)
     add_warning(app, "G_Req_Traceability", check_g_reqid_traceability)
     add_warning(app, "G_Req_Id_Title", check_id_title_part)

--- a/docs/_tooling/sphinx_extensions/test/check_options_test.py
+++ b/docs/_tooling/sphinx_extensions/test/check_options_test.py
@@ -10,7 +10,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-import sys
 from unittest.mock import ANY, MagicMock
 
 import pytest
@@ -21,6 +20,7 @@ from docs._tooling.extensions.score_metamodel.metamodel import (
     needs_types as production_needs_types,
 )
 from docs._tooling.sphinx_extensions.sphinx_extensions.check_options import (
+    check_extra_options,
     check_options,
 )
 
@@ -38,9 +38,22 @@ class TestCheckOptions:
         {
             "directive": "tool_req",
             "req_opt": [
-                ("some_option", "^some_value__.*$"),
+                ("id", "^TOOL_REQ__.*$"),
+                ("some_required_option", "^some_value__.*$"),
             ],
-        },
+        }
+    ]
+    NEED_TYPE_INFO_WITH_OPT_OPT = [
+        {
+            "directive": "tool_req",
+            "req_opt": [
+                ("id", "^TOOL_REQ__.*$"),
+                ("some_required_option", "^some_value__.*$"),
+            ],
+            "opt_opt": [
+                ("some_optional_option", "^some_value__.*$"),
+            ],
+        }
     ]
 
     assert type(NEED_TYPE_INFO) == type(production_needs_types)  # noqa: E721
@@ -57,41 +70,76 @@ class TestCheckOptions:
             target_id="TOOL_REQ__001",
             id="TOOL_REQ__001",
             type="tool_req",
-            some_option="some_value__001",
+            some_required_option="some_value__001",
             docname=None,
             lineno=None,
         )
 
         # Expect that the checks pass
         assert check_options(need, self.LOGGER, self.NEED_TYPE_INFO) is False
+
+    def test_known_directive_with_optional_and_mandatory_option_and_allowed_value(self):
+        # Given a need with a type that is listed in the optional options
+        #  and optional options present
+        #  and with correct values
         need = NeedsInfoType(
             target_id="TOOL_REQ__001",
             id="TOOL_REQ__001",
             type="tool_req",
-            some_option="some_value__001",
+            some_required_option="some_value__001",
+            some_optional_option="some_value__001",
             docname=None,
             lineno=None,
         )
 
         # Expect that the checks pass
-        assert check_options(need, self.LOGGER, self.NEED_TYPE_INFO) is False
+        assert (
+            check_options(need, self.LOGGER, self.NEED_TYPE_INFO_WITH_OPT_OPT) is False
+        )
 
-    def test_unknown_option_present(self):
+    def test_unknown_option_present_in_req_opt(self):
         # Given a need with an option that is not listed in the required options
         need = NeedsInfoType(
             target_id="TOOL_REQ__001",
-            id="TOOL_REQ__001",
+            id="TOOL_REQ__0011",
             type="tool_req",
-            some_option="some_value__001",
+            some_required_option="some_value__001",
             other_option="some_other_value",
             docname=None,
             lineno=None,
         )
 
         # Expect that the checks pass
-        assert check_options(need, self.LOGGER, self.NEED_TYPE_INFO) is False
+        assert check_extra_options(need, self.LOGGER, self.NEED_TYPE_INFO) is True
+        self.LOGGER.warning.assert_called_with(
+            f'Need: {need["id"]} have these extra options: `other_option`.',
+            location=ANY,
+        )
 
-    def test_known_option_missing(self):
+    def test_unknown_option_present_in_neither_req_opt_neither_opt_opt(self):
+        # Given a need with an option that is not listed in the required and optional options
+        need = NeedsInfoType(
+            target_id="TOOL_REQ__001",
+            id="TOOL_REQ__0011",
+            type="tool_req",
+            some_required_option="some_value__001",
+            some_optional_option="some_value__001",
+            other_option="some_other_value",
+            docname=None,
+            lineno=None,
+        )
+
+        # Expect that the checks pass
+        assert (
+            check_extra_options(need, self.LOGGER, self.NEED_TYPE_INFO_WITH_OPT_OPT)
+            is True
+        )
+        self.LOGGER.warning.assert_called_with(
+            f'Need: {need["id"]} have these extra options: `other_option`.',
+            location=ANY,
+        )
+
+    def test_known_required_option_missing(self):
         # Given a need without an option that is listed in the required options
         need = NeedsInfoType(
             target_id="TOOL_REQ__001",
@@ -104,17 +152,17 @@ class TestCheckOptions:
         # Expect that the checks fail and a warning is logged
         assert check_options(need, self.LOGGER, self.NEED_TYPE_INFO) is True
         self.LOGGER.warning.assert_called_with(
-            f'Need: {need["id"]} is missing required option: `some_option`.',
+            f'Need: {need["id"]} is missing required option: `some_required_option`.',
             location=ANY,
         )
 
-    def test_value_violates_pattern(self):
+    def test_value_violates_pattern_for_required_option(self):
         # Given a need with an option that is listed in the required options but the value violates the pattern
         need = NeedsInfoType(
             target_id="TOOL_REQ__001",
             id="TOOL_REQ__001",
             type="tool_req",
-            some_option="some_value_001",
+            some_required_option="some_value_001",
             docname=None,
             lineno=None,
         )
@@ -122,6 +170,27 @@ class TestCheckOptions:
         # Expect that the checks fail and a warning is logged
         assert check_options(need, self.LOGGER, self.NEED_TYPE_INFO) is True
         self.LOGGER.warning.assert_called_with(
-            f'Need: {need["id"]} option `some_option` with value `{need["some_option"]}` does not follow pattern `{self.NEED_TYPE_INFO[0]["req_opt"][0][1]}`.',
+            f'Need: {need["id"]} required option `some_required_option` with value `{need["some_required_option"]}` does not follow pattern `{self.NEED_TYPE_INFO[0]["req_opt"][1][1]}`.',
+            location=ANY,
+        )
+
+    def test_value_violates_pattern_for_optional_option(self):
+        # Given a need with an option that is listed in the optional options but the value violates the pattern
+        need = NeedsInfoType(
+            target_id="TOOL_REQ__001",
+            id="TOOL_REQ__001",
+            type="tool_req",
+            some_required_option="some_value__001",
+            some_optional_option="some_value_001",
+            docname=None,
+            lineno=None,
+        )
+
+        # Expect that the checks fail and a warning is logged
+        assert (
+            check_options(need, self.LOGGER, self.NEED_TYPE_INFO_WITH_OPT_OPT) is True
+        )
+        self.LOGGER.warning.assert_called_with(
+            f'Need: {need["id"]} optional option `some_optional_option` with value `{need["some_optional_option"]}` does not follow pattern `{self.NEED_TYPE_INFO_WITH_OPT_OPT[0]["opt_opt"][0][1]}`.',
             location=ANY,
         )


### PR DESCRIPTION
In this PR we completed part 1 from this task https://github.com/eclipse-score/score/issues/204
We added checks for optional options.
 We also checked all mandatory options for every type of need which are normally requirement options plus optional options plus some list of default options that usually exist in need as well as we adapted the tests for each of them