### PR TITLE
docs: Add version switcher

### DIFF
--- a/.github/actions/deploy-versioned-pages/action.yml
+++ b/.github/actions/deploy-versioned-pages/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: true
   versions_file:
     description: "Path to the versions file on gh-pages branch"
-    default: "versions"
+    default: "versions.json"
   create_comment:
     description: "Create a comment on the PR with the URL to the documentation" # in case of PR
     default: "true"
@@ -61,8 +61,28 @@ runs:
         # Add the target folder to the versions file
         git fetch origin gh-pages --depth 1
         git checkout origin/gh-pages -- "${{ inputs.versions_file }}"
-        if ! grep -qx "${{ steps.calc.outputs.target_folder }}" "${{ inputs.versions_file }}"; then
-          echo "${{ steps.calc.outputs.target_folder }}" >> "${{ inputs.versions_file }}"
+
+        target="${{ steps.calc.outputs.target_folder }}"
+        if [ "$target" = "/" ]; then
+          new_version="stable"
+        else
+          new_version="$target"
+        fi
+
+        if jq -e --arg version "$new_version" 'map(select(.version == $version)) | length > 0' "${{ inputs.versions_file }}" > /dev/null; then
+          echo "Version '$new_version' already exists in ${{ inputs.versions_file }}"
+        else
+          REPO_NAME=$(basename ${{ github.repository }})
+          USER_NAME=$(echo ${{ github.repository }} | cut -d'/' -f1)
+          GITHUB_PAGES_URL="https://${USER_NAME}.github.io/${REPO_NAME}"
+          if [ "$target" = "/" ]; then
+            new_url="${GITHUB_PAGES_URL}/"
+          else
+            new_url="${GITHUB_PAGES_URL}/$target/"
+          fi
+
+          jq --arg version "$new_version" --arg url "$new_url" '. + [{"version": $version, "url": $url}]' "${{ inputs.versions_file }}" > tmp_versions.json
+          mv tmp_versions.json "${{ inputs.versions_file }}"
         fi
         mv "${{ inputs.versions_file }}" deploy_root/
         ls -al .

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -41,7 +41,11 @@ jobs:
 
           # Delete the folder and remove the version from the versions file
           rm -rf "${VERSION}"
-          sed -i "/^$VERSION$/d" versions
+
+          # Remove from versions.json
+          if [[ -f versions.json ]]; then
+            jq --arg ver "$VERSION" 'map(select(.version != $ver))' versions.json > tmp.json && mv tmp.json versions.json
+          fi
       - name: Push changes to gh-pages branch
         uses: EndBug/add-and-commit@v9
         with:

--- a/docs/_tooling/assets/css/score.css
+++ b/docs/_tooling/assets/css/score.css
@@ -239,3 +239,13 @@ html[data-theme="dark"] #score-title {
     100% { opacity: 1; }
   }
 
+/* Ensure the version switcher dropdown is scrollable if it exceeds the max height */
+.version-switcher__menu {
+    position: absolute;
+    width: 100%;
+    max-height: 300px; /* Adjust this value as needed */
+    overflow-y: auto;
+    overflow-x: hidden;
+    box-sizing: border-box;
+}
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,14 @@ html_css_files = [
     "css/score_design.css",
 ]
 
+html_context = {
+    # "github_url": "https://github.com", # or your GitHub Enterprise site
+    "github_user": "eclipse-score",
+    "github_repo": "score",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
 html_theme_options = {
     "navbar_align": "content",
     "header_links_before_dropdown": 5,
@@ -98,14 +106,12 @@ html_theme_options = {
     "logo": {
         "text": "Eclipse SCORE Docs",
     },
-}
-
-html_context = {
-    # "github_url": "https://github.com", # or your GitHub Enterprise site
-    "github_user": "eclipse-score",
-    "github_repo": "score",
-    "github_version": "main",
-    "doc_path": "docs",
+    # Enable version switcher
+    "switcher": {
+        "json_url": f"https://{html_context['github_user']}.github.io/{html_context['github_repo']}/versions.json",  # URL to JSON file, hardcoded for now
+        "version_match": release,
+    },
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
 }
 
 # -- sphinx-needs configuration --------------------------------------------


### PR DESCRIPTION
# Improvement

## Description

Use current theme(pydata_sphinx_theme) [version switcher dropdown](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html#) to display a version selector. Because the switcher requires a json, the versions file is parsed into versions.json. 
Also a css update of the version switcher is required to proper display(vertical scrollbar) the list of versions.

Because of a current bug #194 this PR will not show the docs preview. However I created another PR for preview only: https://nicu1989.github.io/score/pr-7/

Here is also a picture of the dropdown:

<img width="285" alt="image" src="https://github.com/user-attachments/assets/a4a9008c-6d87-4e69-a9fe-306fb5a396ab" />

Also there is a way to view the versions file in browser using the json file: https://eclipse-score.github.io/score/versions.json

## Related ticket


closes [#250 ] (improvement ticket)