### PR TITLE
docs: Added decision records for python tooling

### DIFF
--- a/tools/decision_records/python_tooling.md
+++ b/tools/decision_records/python_tooling.md
@@ -1,0 +1,44 @@
+# Decision Record: Python Tooling
+
+## Context
+Selection of Python development tools for consistent code quality and maintainability, regarding the following categories:
+
+- Code formatting and linting
+- Type checking and static analysis
+- Testing and coverage
+
+## Decision
+| Category | Selected Tool | Purpose |
+|----------|---------------|----------|
+| Formatting & Linting | [Ruff](https://github.com/astral-sh/ruff) | Code style enforcement |
+| Type Checking | [pyright](https://github.com/microsoft/pyright) | Static type analysis |
+| Testing | [pytest](https://github.com/pytest-dev/pytest/) | Test framework |
+| Coverage | [pytest-cov](https://github.com/pytest-dev/pytest-cov) | Test coverage reporting |
+| Static Analysis | [pylint](https://github.com/pylint-dev/pylint) | Code quality analysis |
+
+
+### Tool Selection Criteria
+- Established open-source adoption
+- Team familiarity and consensus
+- High test coverage (verified)
+  - pyright: 99% (local verification)
+  - pytest: 97% ([source](https://app.codecov.io/gh/pytest-dev/pytest))
+  - pylint: 96% ([source](https://app.codecov.io/gh/pylint-dev/pylint))
+
+### Alternatives Considered
+
+#### Formatting & Linting
+- Flake8: Replaced by Ruff's equivalent functionality
+- Black: Integrated into Ruff
+- Pylint: Retained for static analysis, but using Ruff for linting due to speed
+
+#### Type Checking
+- mypy: 
+
+#### Testing
+- unittest: Limited feature set
+- hypothesis: Team unfamiliarity
+
+#### Coverage
+- coverage.py: 
+- radon: Team unfamiliarity

--- a/tools/decision_records/python_tooling.md
+++ b/tools/decision_records/python_tooling.md
@@ -1,44 +1,61 @@
-# Decision Record: Python Tooling
+# Decision Record: Python Tooling Selection
+
+## Status
+Agreed
 
 ## Context
-Selection of Python development tools for consistent code quality and maintainability, regarding the following categories:
+Selection of Python development tools needs to be made to ensure consistent code quality and maintainability across our codebase.   
+This decision covers core development tool selection in these categories:
 
 - Code formatting and linting
 - Type checking and static analysis
 - Testing and coverage
 
+Note: Tool configurations will be determined in a separate decision record.
+
 ## Decision
+We will use the following tools:
+
 | Category | Selected Tool | Purpose |
 |----------|---------------|----------|
-| Formatting & Linting | [Ruff](https://github.com/astral-sh/ruff) | Code style enforcement |
-| Type Checking | [pyright](https://github.com/microsoft/pyright) | Static type analysis |
-| Testing | [pytest](https://github.com/pytest-dev/pytest/) | Test framework |
-| Coverage | [pytest-cov](https://github.com/pytest-dev/pytest-cov) | Test coverage reporting |
-| Static Analysis | [pylint](https://github.com/pylint-dev/pylint) | Code quality analysis |
-
+| Formatting & Linting | Ruff | Fast code style enforcement and formatting |
+| Type Checking | pyright | Static type analysis |
+| Testing | pytest | Test framework |
+| Coverage | pytest-cov | Test coverage reporting |
+| Static Analysis | pylint | Code quality analysis |
 
 ### Tool Selection Criteria
-- Established open-source adoption
+Our tools were chosen based on:
+- Established open-source adoption and stability
 - Team familiarity and consensus
-- High test coverage (verified)
+- Proven reliability through their own test coverage:
   - pyright: 99% (local verification)
-  - pytest: 97% ([source](https://app.codecov.io/gh/pytest-dev/pytest))
-  - pylint: 96% ([source](https://app.codecov.io/gh/pylint-dev/pylint))
+  - pytest: 97% (codecov.io verification)
+  - pylint: 96% (codecov.io verification)
+
+### Tools Compatibility
+All selected tools support Python version 3.12 used inside the project.
 
 ### Alternatives Considered
 
 #### Formatting & Linting
-- Flake8: Replaced by Ruff's equivalent functionality
-- Black: Integrated into Ruff
-- Pylint: Retained for static analysis, but using Ruff for linting due to speed
+- Flake8: While well-established, Ruff provides equivalent functionality with significantly better performance
+- Black: Now integrated into Ruff, making a separate Black installation unnecessary
+- Using only Pylint: While we're keeping Pylint for static analysis, Ruff's speed makes it superior for day-to-day linting
 
 #### Type Checking
-- mypy: 
+- mypy: While mypy is the original Python type checker, pyright was chosen for:
+  - Better performance on large codebases
+  - More detailed error messages
+  - VS Code integration through Pylance
 
 #### Testing
-- unittest: Limited feature set
-- hypothesis: Team unfamiliarity
+- unittest: Rejected due to:
+  - Limited fixture support
+  - More verbose test writing
+  - Fewer plugins compared to pytest
+- hypothesis: Features it provides are currently not needed; this, in combination with team unfamiliarity, makes pytest the better option
 
 #### Coverage
-- coverage.py: 
-- radon: Team unfamiliarity
+- coverage.py: Chose pytest-cov for direct pytest integration and simpler workflow
+- radon: More focused on complexity metrics than coverage reporting, which doesn't match our immediate needs

--- a/tools/decision_records/python_tooling.md
+++ b/tools/decision_records/python_tooling.md
@@ -4,7 +4,7 @@
 Agreed
 
 ## Context
-Selection of Python development tools needs to be made to ensure consistent code quality and maintainability across our codebase.   
+Selection of Python development tools needs to be made to aid in consistent code quality and maintainability across our codebase.   
 This decision covers core development tool selection in these categories:
 
 - Code formatting and linting


### PR DESCRIPTION
Decision record to clarify & write down decisions and results of discussions made in slack voting & meetings regarding python tooling. 


Feedback on wording, missing reasons for inclusions  & exclusions and content are welcome. 