### PR TITLE
cr_checker: Add `remove offset` option

### DIFF
--- a/tools/cr_checker/cr_checker.bzl
+++ b/tools/cr_checker/cr_checker.bzl
@@ -21,6 +21,7 @@ def copyright_checker(
         config = "//tools/cr_checker/resources:config",
         extensions = [],
         offset = 0,
+        remove_offset = 0,
         debug = False,
         use_memory_map = False,
         fix = False):
@@ -40,6 +41,8 @@ def copyright_checker(
         extensions (list, optional): A list of file extensions to filter the source files.
                                      Defaults to an empty list, meaning all files are checked.
         offset (int, optional): The line offset for applying checks or modifications.
+                                Defaults to 0.
+        remove_offset (int, optional): The line offset for removing chars from begining of file.
                                 Defaults to 0.
         debug (bool, optional): Whether to enable debug mode, providing additional logs.
                                 Defaults to False.
@@ -81,6 +84,8 @@ def copyright_checker(
     for t_name in t_names:
         if t_name == "{}.fix".format(name):
             args.insert(0, "--fix")
+            if remove_offset:
+                args.append("--remove_offset {}".format(remove_offset))
 
         native.py_binary(
             name = t_name,

--- a/tools/cr_checker/tool/README.md
+++ b/tools/cr_checker/tool/README.md
@@ -10,6 +10,7 @@
 - Can use memory mapping for large file handling.
 - Customizable file encoding and offset adjustments for header text positioning.
 - Can append copyright headers.
+- Can remove provided number of characters from begining of the file.
 
 ## Requirements
 
@@ -38,7 +39,10 @@ python cr_checker.py -t <template_file> [options] <inputs>
 - **--encoding**: File encoding (default is utf-8).
 - **--offset**: Additional offset for the header length to account for lines like a shebang.
 - **--fix**: Setting script into fix mode where copyright header will be added to the files if it's missing from same.
+- **--remove-offset**: Number of characters to remove before appending proper copyright header (works only with `--fix` option).
 - **inputs**: (Required) Directories or files to parse, or a parameter file prefixed with @ that lists files or directories.
+
+> NOTE: Option `--remove-offset` can have severe consequences if the offset is miscalculated. Use with **extreme caution**.
 
 ### Examples
 


### PR DESCRIPTION
The new option enables the removal of outdated copyright headers from source files. This functionality is potentially destructive and should be used with extreme caution.