### PR TITLE
Enable Plantuml syntax error image

### DIFF
--- a/docs/_tooling/extensions/score_plantuml.py
+++ b/docs/_tooling/extensions/score_plantuml.py
@@ -103,6 +103,7 @@ def get_runfiles_dir() -> Path:
 def setup(app: Sphinx):
     app.config.plantuml = str(get_plantuml_path())
     app.config.plantuml_output_format = "svg_obj"
+    app.config.plantuml_syntax_error_image = True
 
     logger.debug(f"PlantUML binary found at {app.config.plantuml}")
 


### PR DESCRIPTION
If a plantuml figure cannot be rendered an error image containing the error message will be displayed