### PR TITLE
docs: Fix documentation header display

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,15 +105,12 @@ html_theme_options = {
     # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/source-buttons.html#add-an-edit-button
     "use_edit_page_button": True,
     "collapse_navigation": True,
-    "logo": {
-        "text": "Eclipse SCORE Docs",
-    },
     # Enable version switcher
     "switcher": {
         "json_url": f"https://{html_context['github_user']}.github.io/{html_context['github_repo']}/versions.json",  # URL to JSON file, hardcoded for now
         "version_match": release,
     },
-    "navbar_end": ["version-switcher", "navbar-icon-links"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links", "version-switcher"],
 }
 
 html_context = {


### PR DESCRIPTION
# Bugfix


## Description

Remove title(since its replaced by logo) and re-added missing theme switcher(dark/light mode).

![image](https://github.com/user-attachments/assets/ca2cf106-530c-4c35-b0a0-0d46e7005b5e)


## Related ticket

closes [#325 ] (bugfix ticket)