### PR TITLE
ci: Fix multiple PR comments with docs link

### DIFF
--- a/.github/actions/deploy-versioned-pages/action.yml
+++ b/.github/actions/deploy-versioned-pages/action.yml
@@ -108,9 +108,17 @@ runs:
         folder: version_root
         clean: false
 
+    - name: Find Comment
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: peter-evans/find-comment@v3
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: The created documentation from the pull request
 
     - name: Comment on PR with docs URL
-      if: ${{ github.event_name == 'pull_request_target' && inputs.create_comment == 'true' }}
+      if: ${{ github.event_name == 'pull_request_target' && inputs.create_comment == 'true' && steps.fc.outputs.comment-id == '' }}
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{github.event.pull_request.number}}


### PR DESCRIPTION
# Improvement

## Description

Every commit on a PR will trigger CI step to post the same comment.
Now only the initial PR comment will be posted.

**Note:** When triggering a workflow by pull_request_target the workflow that runs is the one from the target branch of the PR.
This means that until this PR is merged the comment will be published multiple times(as it currently does) including for this PR.

There is a github community discussion here: https://github.com/orgs/community/discussions/25437 

## Related ticket

closes #391 