### PR TITLE
dash: Add README.md and move target to docs directory

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,6 @@
 # *******************************************************************************
 
 load("//tools/cr_checker:cr_checker.bzl", "copyright_checker")
-load("//tools/dash:dash.bzl", "dash_license_checker")
 
 test_suite(
     name = "format.check",
@@ -33,12 +32,6 @@ copyright_checker(
         "//:BUILD",
         "//:MODULE.bazel",
     ],
-    visibility = ["//visibility:public"],
-)
-
-dash_license_checker(
-    name = "python",
-    src = "//docs:requirements_lock",
     visibility = ["//visibility:public"],
 )
 

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -43,6 +43,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs")
+load("//tools/dash:dash.bzl", "dash_license_checker")
 load("//tools/testing/pytest:defs.bzl", "score_py_pytest")
 
 sphinx_requirements = all_requirements + [
@@ -186,5 +187,11 @@ filegroup(
     srcs = [
         "_tooling/requirements_lock.txt",
     ],
+    visibility = ["//visibility:public"],
+)
+
+dash_license_checker(
+    name = "python",
+    src = "//docs:requirements_lock",
     visibility = ["//visibility:public"],
 )

--- a/tools/dash/README.md
+++ b/tools/dash/README.md
@@ -1,0 +1,61 @@
+# DASH License Checker Bazel Integration
+
+This directory provides Bazel build configurations and custom rules to integrate the DASH license checker into projects. The setup includes a macro to define a java_binary target for license validation and a custom rule for converting requirement files into the appropriate DASH format.
+
+## Directory Structure
+
+```bash
+├── BUILD
+├── dash.bzl
+├── formatters
+│   ├── BUILD
+│   ├── dash_format_converter.bzl
+│   └── dash_format_converter.py
+└── README.md
+```
+
+### File Descriptions
+
+**BUILD**
+
+- This file is empty and serves only to mark this directory as a Bazel package.
+
+**dash.bzl**
+
+- Contains the dash_license_checker macro, which defines a `java_binary` target to run the DASH license checker.
+- Loads `dash_format_converter.bzl` from the `formatters` package to preprocess requirement files.
+- Converts the input `requirements_lock.txt` file into a format compatible with the DASH license tool before invoking the Java-based checker.
+
+**formatters/BUILD**
+
+- Empty file indicating that formatters is a Bazel package.
+
+**formatters/dash_format_converter.bzl**
+
+- Defines a custom Bazel rule `dash_format_converter`.
+- Calls `dash_format_converter.py` to transform `requirements_lock.txt` into a format that the DASH tool can process.
+
+**formatters/dash_format_converter.py**
+
+- Implements the logic to convert `requirements_lock.`txt into a format accepted by the DASH license checker.
+- This script is executed as part of the `dash_format_converter` Bazel rule.
+
+## Usage
+
+To integrate the DASH license checker into your Bazel project, define a target in your `BUILD` file as follows:
+
+```bash
+load("//tools/dash:dash.bzl", "dash_license_checker")
+
+dash_license_checker(
+    name = "my_project_license_check",
+    src = "//path/to/requirements_lock.txt",
+    visibility = ["//visibility:public"],
+)
+```
+
+This will:
+
+1. Use dash_format_converter to process requirements_lock.txt.
+2. Create a java_binary target that executes the DASH license checker with the converted file.
+3. Ensure compliance with dependency licensing requirements in your project.

--- a/tools/dash/dash.bzl
+++ b/tools/dash/dash.bzl
@@ -37,7 +37,7 @@ def dash_license_checker(
     validation across projects.
     """
     dash_format_converter(
-        name = "formatted_deps",
+        name = "{}2dash".format(name),
         requirement_file = src,
     )
 
@@ -47,9 +47,9 @@ def dash_license_checker(
         runtime_deps = [
             "@dash_license_tool//jar",
         ],
-        args = ["$(location :formatted_deps)"],
+        args = ["$(location :{}2dash)".format(name)],
         data = [
-            ":formatted_deps",
+            ":{}2dash".format(name),
         ],
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
The README.md provides better insignt how Bazel and Dash (EF License checker) communicate and work in chain. Also the target for checking Python licenses is moved to docs directory.