### PR TITLE
tooling: Correct upper case values in docs build errors.

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/checks/id_format_and_length.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/id_format_and_length.py
@@ -12,8 +12,8 @@
 # *******************************************************************************
 import os
 
-from sphinx_needs.data import NeedsInfoType
 from sphinx.application import Sphinx
+from sphinx_needs.data import NeedsInfoType
 
 from score_metamodel import CheckLogger, local_check
 
@@ -28,7 +28,7 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     # Split the string by underscores
     parts = need["id"].split("__")
 
-    if need["type"].startswith(("gd_", "wf_", "wp_")):
+    if need["id"].startswith(("gd_", "wf__", "wp__")):
         if len(parts) != 2 and len(parts) != 3:
             msg = "expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`."
             log.warning_for_option(need, "id", msg)

--- a/docs/_tooling/extensions/score_metamodel/checks/traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/traceability.py
@@ -10,11 +10,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
 
 from score_metamodel import CheckLogger, graph_check
-
-from sphinx.application import Sphinx
 
 
 # req-traceability: TOOL_REQ__toolchain_sphinx_needs_build__requirement_linkage_status

--- a/docs/_tooling/extensions/score_metamodel/tests/test_id_format_and_length.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_id_format_and_length.py
@@ -29,7 +29,7 @@ class TestId:
         """
 
         need = NeedsInfoType(
-            id="GD_REQ__attribute_satisfies",
+            id="gd_req_attribute_satisfies",
         )
 
         logger = fake_check_logger()
@@ -43,7 +43,7 @@ class TestId:
         """
 
         need = NeedsInfoType(
-            id="GD_REQ_attribute_satisfies",
+            id="gd_req_attribute_satisfies",
         )
 
         logger = fake_check_logger()
@@ -62,7 +62,7 @@ class TestId:
         """
 
         need = NeedsInfoType(
-            id="TOOL_REQ__1",
+            id="tool_req__1",
         )
 
         logger = fake_check_logger()
@@ -81,7 +81,7 @@ class TestId:
         """
 
         need = NeedsInfoType(
-            id="STD_REQ_ISO26262__rq_8_6432",
+            id="std_req__iso26262__rq_8_6432",
         )
 
         logger = fake_check_logger()
@@ -95,7 +95,7 @@ class TestId:
         """
 
         need = NeedsInfoType(
-            id="STD_REQ_ISO26262__rq_8_6432_00000000000",
+            id="std_req__iso26262__rq_8_6432_00000000000",
         )
 
         logger = fake_check_logger()

--- a/docs/features/communication/ipc/index.rst
+++ b/docs/features/communication/ipc/index.rst
@@ -16,7 +16,7 @@ Inter-process Communication
 ===========================
 
 .. document:: Inter-process Communication
-   :id: DOC__IPC
+   :id: doc__ipc
    :status: valid
    :safety: ASIL_B
    :tags: contribution_request, feature_request

--- a/docs/features/communication/ipc/requirements/index.rst
+++ b/docs/features/communication/ipc/requirements/index.rst
@@ -19,41 +19,41 @@ High cohesion and loose coupling
 ================================
 
 .. feat_req:: Support for Time-based Architecture
-   :id: FEAT_REQ__ipc__time_based_arch
+   :id: feat_req__ipc__time_based_arch
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__281
+   :satisfies: stkh_req__2,stkh_req__281
    :status: valid
 
    The communication framework shall provide API to support a time-based architecture.
 
 .. feat_req:: Support for Data-driven Architecture
-   :id: FEAT_REQ__ipc__data_driven_arch
+   :id: feat_req__ipc__data_driven_arch
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__282
+   :satisfies: stkh_req__2,stkh_req__282
    :status: valid
 
    The communication framework shall provide API to support a data-driven architecture.
 
 .. feat_req:: Support for Request-driven Architecture
-   :id: FEAT_REQ__ipc__request_driven_arch
+   :id: feat_req__ipc__request_driven_arch
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__282
+   :satisfies: stkh_req__2,stkh_req__282
    :status: valid
 
    The communication framework shall provide API to support a request-driven architecture.
 
 .. feat_req:: Communication Interfaces
-   :id: FEAT_REQ__ipc__interfaces
+   :id: feat_req__ipc__interfaces
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2,STKH_REQ__282,STKH_REQ__283
+   :satisfies: stkh_req__2,stkh_req__282,stkh_req__283
    :status: valid
 
    A communication interface consists of a combination of any number of the following elements:
@@ -63,11 +63,11 @@ High cohesion and loose coupling
    - Signals
 
 .. feat_req:: Event Type
-   :id: FEAT_REQ__ipc__event_type
+   :id: feat_req__ipc__event_type
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__282
+   :satisfies: stkh_req__2,stkh_req__282
    :status: valid
 
    An event-type is part of a communication interface and has:
@@ -79,11 +79,11 @@ High cohesion and loose coupling
    Consumers can subscribe to value-changed events of the element or poll unseen, cached events.
 
 .. feat_req:: Method
-   :id: FEAT_REQ__ipc__method
+   :id: feat_req__ipc__method
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__283
+   :satisfies: stkh_req__2,stkh_req__283
    :status: valid
 
    A method is part of a communication interface and has:
@@ -99,11 +99,11 @@ High cohesion and loose coupling
    A method call shall be possible both synchronously and asynchronously.
 
 .. feat_req:: Signal
-   :id: FEAT_REQ__ipc__signal
+   :id: feat_req__ipc__signal
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__281
+   :satisfies: stkh_req__2,stkh_req__281
    :status: valid
 
    A signal is part of a communication interface and has:
@@ -121,21 +121,21 @@ High cohesion and loose coupling
    Hypervisor Signalling APIs may be chosen.
 
 .. feat_req:: Producer-Consumer Pattern
-   :id: FEAT_REQ__ipc__producer_consumer
+   :id: feat_req__ipc__producer_consumer
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2,STKH_REQ__281
+   :satisfies: stkh_req__2,stkh_req__281
    :status: valid
 
    Communication shall be cached based on the producer-consumer pattern.
 
 .. feat_req:: Service Instance
-   :id: FEAT_REQ__ipc__service_instance
+   :id: feat_req__ipc__service_instance
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    A communication interface that is offered to consumers is called a service instance.
@@ -143,11 +143,11 @@ High cohesion and loose coupling
    Multiple service instances shall be able to offer the same interface.
 
 .. feat_req:: Service Instance Names
-   :id: FEAT_REQ__ipc__service_instance_names
+   :id: feat_req__ipc__service_instance_names
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    A service instance is offered under one or more unique names by which it can be discovered.
@@ -158,11 +158,11 @@ High cohesion and loose coupling
 
 
 .. feat_req:: Versioning
-   :id: FEAT_REQ__ipc__versioning
+   :id: feat_req__ipc__versioning
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support versioning of service instances.
@@ -173,22 +173,22 @@ High cohesion and loose coupling
    Multiple service instances can have the same interface and version.
 
 .. feat_req:: Service location transparency
-   :id: FEAT_REQ__ipc__service_location_transparency
+   :id: feat_req__ipc__service_location_transparency
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The interface to access service instances is agnostic to the binding used to communicate with the service.
    Note: Deployment information may require manual changes based on where the service is located.
 
 .. feat_req:: Stateless communication
-   :id: FEAT_REQ__ipc__stateless_communication
+   :id: feat_req__ipc__stateless_communication
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support stateless communication.
@@ -197,22 +197,22 @@ High cohesion and loose coupling
    - In case of RPC, the skeleton is not aware of the proxy, this request originated from.
 
 .. feat_req:: Service instance_granularity
-   :id: FEAT_REQ__ipc__service_instance_granularity
+   :id: feat_req__ipc__service_instance_granularity
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support multiple service instances per software architecture element.
    Note: A software architecture element is for example an application, activity, proces, ...
 
 .. feat_req:: Service discovery
-   :id: FEAT_REQ__ipc__service_discovery
+   :id: feat_req__ipc__service_discovery
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall provide service discovery to find available services during runtime.
@@ -224,54 +224,54 @@ Mixed-Criticality safety systems
 ================================
 
 .. feat_req:: Safe communication over criticality levels
-   :id: FEAT_REQ__ipc__safe_communication
+   :id: feat_req__ipc__safe_communication
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support safe communication involving communication partners on the same or multiple
    criticality levels.
 
 .. feat_req:: Data Corruption
-   :id: FEAT_REQ__ipc__data_corruption
+   :id: feat_req__ipc__data_corruption
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    Consumers with lower criticality shall not be able to corrupt data consumed by partners with higher criticality.
 
 .. feat_req:: Data Reordering
-   :id: FEAT_REQ__ipc__data_reordering
+   :id: feat_req__ipc__data_reordering
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    Consumers with lower criticality shall not be able to modify the order of data consumed by partners with higher
    criticality.
 
 .. feat_req:: Data Repetition
-   :id: FEAT_REQ__ipc__data_repetition
+   :id: feat_req__ipc__data_repetition
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    Consumers with lower criticality shall not be able to duplicate data consumed by other communication partners with
    higher criticality.
 
 .. feat_req:: Data Loss
-   :id: FEAT_REQ__ipc__data_loss
+   :id: feat_req__ipc__data_loss
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    Consumers with lower criticality shall not be able to drop data before it is consumed by partners with higher
@@ -281,11 +281,11 @@ Performance
 ===========
 
 .. feat_req:: Zero-Copy IPC
-   :id: FEAT_REQ__ipc__zero_copy
+   :id: feat_req__ipc__zero_copy
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2,STKH_REQ__282
+   :satisfies: stkh_req__2,stkh_req__282
    :status: valid
 
    IPC communication shall be possible without copying to-be-transferred data.
@@ -294,31 +294,31 @@ User friendly API for information exchange
 ==========================================
 
 .. feat_req:: Support for multiple programming languages
-   :id: FEAT_REQ__ipc__multi_lang
+   :id: feat_req__ipc__multi_lang
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__260
+   :satisfies: stkh_req__260
    :status: valid
 
    The communication framework shall provide a public API for each supported programming language of SCORE.
 
 .. feat_req:: Support for programming language idioms
-   :id: FEAT_REQ__ipc__lang_idioms
+   :id: feat_req__ipc__lang_idioms
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__260
+   :satisfies: stkh_req__260
    :status: valid
 
    Each public API shall support the idioms of the programming language it is written in.
 
 .. feat_req:: Use programming language infrastructure
-   :id: FEAT_REQ__ipc__lang_infra
+   :id: feat_req__ipc__lang_infra
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__260
+   :satisfies: stkh_req__260
    :status: valid
 
    Each public API shall use core infrastructure of its programming language and accompanying standard libraries,
@@ -330,21 +330,21 @@ Full testability for the user facing API
 ========================================
 
 .. feat_req:: Fully mockable public API
-   :id: FEAT_REQ__ipc__testability_mock_api
+   :id: feat_req__ipc__testability_mock_api
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The public API shall be fully mockable.
 
 .. feat_req:: Fake binding
-   :id: FEAT_REQ__ipc__testability_fake_binding
+   :id: feat_req__ipc__testability_fake_binding
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall provide a fake binding.
@@ -353,11 +353,11 @@ Multi-binding support
 =====================
 
 .. feat_req:: Multi-binding support
-   :id: FEAT_REQ__ipc__multi_binding_support
+   :id: feat_req__ipc__multi_binding_support
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support multiple bindings.
@@ -367,11 +367,11 @@ Multi-binding support
    It does this either directly or via a gateway approach.
 
 .. feat_req:: Binding-agnostic public API
-   :id: FEAT_REQ__ipc__binding_agnostic_api
+   :id: feat_req__ipc__binding_agnostic_api
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The public API of the communication framework shall be binding-agnostic.
@@ -381,11 +381,11 @@ Multi-binding support
    binding is exchanged, the public API remains syntactically and semantically unchanged.
 
 .. feat_req:: Multi-binding deployment configuration
-   :id: FEAT_REQ__ipc__multi_binding_depl
+   :id: feat_req__ipc__multi_binding_depl
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The association of a service instance and the appropriate binding shall be specified in the deployment configuration.
@@ -394,11 +394,11 @@ Dynamic deployment at runtime
 =============================
 
 .. feat_req:: Deployment configuration at runtime
-   :id: FEAT_REQ__ipc__depl_config_runtime
+   :id: feat_req__ipc__depl_config_runtime
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    Deployment configuration shall be read from an integrity-checked configuration file at runtime.
@@ -407,11 +407,11 @@ Tracing
 =======
 
 .. feat_req:: Support for Tracing
-   :id: FEAT_REQ__ipc__tracing
+   :id: feat_req__ipc__tracing
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: STKH_REQ__242
+   :satisfies: stkh_req__242
    :status: valid
 
    The communication framework shall provide infrastructure to enable binding-agnostic, zero-copy, read-only tracing of
@@ -421,31 +421,31 @@ Security Impact
 ===============
 
 .. feat_req:: Access Control List Placement
-   :id: FEAT_REQ__ipc__acl_placement
+   :id: feat_req__ipc__acl_placement
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support an Access Control Lists in the deployment configuration.
 
 .. feat_req:: Access Control List per service instance
-   :id: FEAT_REQ__ipc__acl_per_service_instance
+   :id: feat_req__ipc__acl_per_service_instance
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support an Access Control List per service instance.
 
 .. feat_req:: Access Control List for producer
-   :id: FEAT_REQ__ipc__acl_for_producer
+   :id: feat_req__ipc__acl_for_producer
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support an Access Control List for the communication partner offering a service
@@ -453,11 +453,11 @@ Security Impact
    An entry in the ACL corresponds to an allowed consumer.
 
 .. feat_req:: Access Control List for consumer
-   :id: FEAT_REQ__ipc__acl_for_consumer
+   :id: feat_req__ipc__acl_for_consumer
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support an Access Control List for the communication partner consuming a service
@@ -465,31 +465,31 @@ Security Impact
    An entry in the ACL corresponds to an allowed producer.
 
 .. feat_req:: IPC Confidentiality
-   :id: FEAT_REQ__ipc__confidentiality
+   :id: feat_req__ipc__confidentiality
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The IPC binding shall ensure confidentiality of its communication.
 
 .. feat_req:: IPC Integrity
-   :id: FEAT_REQ__ipc__integrity
+   :id: feat_req__ipc__integrity
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The IPC binding shall ensure integrity of its communication.
 
 .. feat_req:: IPC Availability
-   :id: FEAT_REQ__ipc__availability
+   :id: feat_req__ipc__availability
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
@@ -499,11 +499,11 @@ Safety Impact
 =============
 
 .. feat_req:: IPC ASIL level
-   :id: FEAT_REQ__ipc__asil
+   :id: feat_req__ipc__asil
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: STKH_REQ__2
+   :satisfies: stkh_req__2
    :status: valid
 
    The communication framework shall support safe communication up to ASIL-B.

--- a/docs/process/guidance/contribution_request/index.rst
+++ b/docs/process/guidance/contribution_request/index.rst
@@ -17,13 +17,13 @@
 ###############################
 
 .. gd_guidl:: Contribution Request Guideline
-  :id: GD_GUIDL__Contr_Request_Guideline
+  :id: gd_guidl__contr_request_guideline
   :status: valid
   :tags: contribution_management
 
 Contributions to the *SCORE* project are the key to grow the content including the code. Contributions may cover simple improvement proposals, bug or problem reports, but also more complex scope changes of features up to new feature requests. Depending on the contribution scope, several steps may be required to finally merge it within the *SCORE* repository.
 
-This guidline shall help the contributor (:need:`Contributor <RL_contributor>`) to find the right path for his contribution.
+This guidline shall help the contributor (:need:`Contributor <rl_contributor>`) to find the right path for his contribution.
 
 For simple contributions, like fixing bugs or improvements, just creating a *PR* is sufficient.
 
@@ -61,14 +61,14 @@ For a *PR* to be merged, in any case an approval of a committer is needed. If th
 
 *GitHub Issue* are categorized using various types. For categorizing of PRs using of labels, e.g. bug or improvement, is mandatory, see `Platform Management Plan <https://eclipse-score.github.io/score/platform_management_plan/project_management.html>`_.
 
-For all possibilites the project contains simple templates (provided by committers (:need:`Committer <RL_committer>`)), in particular please use :ref:`Feature Request Template <feature_request_template>` to request a new feature or changes to the existing one.
+For all possibilites the project contains simple templates (provided by committers (:need:`Committer <rl_committer>`)), in particular please use :ref:`Feature Request Template <feature_request_template>` to request a new feature or changes to the existing one.
 
 *****************************
  What is a Pull Request (PR)?
 *****************************
 
 .. gd_guidl:: Pull Request Guideline
-  :id: GD_GUIDL__Pull_Request_Guideline
+  :id: gd_guidl__pull_request_guideline
   :status: valid
   :tags: contribution_management
 
@@ -76,9 +76,9 @@ A Pull Request (**PR**) is the **ONLY** way to contribute **CODE** to the *SCORE
 
 The figure below shows a simplified workflow for a PR.
 
-* The contributor (:need:`Contributor <RL_contributor>`) starts by creating a PR:  `Creating a Pull Request (Github Docs) <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_.
+* The contributor (:need:`Contributor <rl_contributor>`) starts by creating a PR:  `Creating a Pull Request (Github Docs) <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request>`_.
 * Required reviewers will be automatically assigned based on the contributed content (via CODEOWNERS).
-* If the content fullfils the review and acceptance criteria, a committer (:need:`Committer <RL_committer>`) will approve the *PR* and thus it can be merged.
+* If the content fullfils the review and acceptance criteria, a committer (:need:`Committer <rl_committer>`) will approve the *PR* and thus it can be merged.
 
 .. figure:: _assets/score_contribution_request_simple.drawio.svg
   :width: 600
@@ -89,7 +89,7 @@ The figure below shows a simplified workflow for a PR.
 
 Content in general may contain features, requirements, architectural designs, modules, components, detailed designs, implementations and source code, tests, process descriptions, any documentations, guidelines, tutorials, tools, or infrastructure topics and more of the *SCORE* project. In case of doubt or for any other input we strongly encourage to open a *GitHub Issue* (:need:`GD_GUIDL__Issue_Guideline`) first.
 
-The *PR* should provide all required information of the new or changed content. Therefore the *SCORE* project provides content specific templates, which the contributor (:need:`Contributor <RL_contributor>`) must use for his *PR* (ToDo link here to the templates overview). Templates may be *PR* templates, *GitHub Issue* templates and also additional document or work product templates.
+The *PR* should provide all required information of the new or changed content. Therefore the *SCORE* project provides content specific templates, which the contributor (:need:`Contributor <rl_contributor>`) must use for his *PR* (ToDo link here to the templates overview). Templates may be *PR* templates, *GitHub Issue* templates and also additional document or work product templates.
 
 The content of any *PR* is the commit content and the description as well as the comments given in GitHub and is kept in a versioned repository, their revision history is the historical record of the PR.
 
@@ -113,30 +113,30 @@ The figure below gives an overview about all the possible steps for a *PR* until
 Create a PR
 ===========
 
-The contributor (:need:`Contributor <RL_contributor>`) creates a PR.
+The contributor (:need:`Contributor <rl_contributor>`) creates a PR.
 
-Reviewers will be automatically assigned (:need:`Committer <RL_committer>`) based on the contributed content (ruleset as defined by the committers). In addition several checks for the contributed content (ToDo: Link to the description of the checks) will be started.
+Reviewers will be automatically assigned (:need:`Committer <rl_committer>`) based on the contributed content (ruleset as defined by the committers). In addition several checks for the contributed content (ToDo: Link to the description of the checks) will be started.
 
 Review and merge a PR
 =====================
 
-A *PR* is reviewed with all content that adds/modifies it. As long as a *PR* requires further work by the contributor (:need:`Contributor <RL_contributor>`), the *PR* is not approved and thus not merged and further changes are requested. Once the contributor (:need:`Contributor <RL_contributor>`) considers all review comments as resolved, :need:`Contributor <RL_contributor>` can re-request a review. The committer (:need:`Committer <RL_committer>`) reviews the *PR* content according the *SCORE* review and acceptance criteria (ToDo link here to the criteria).
-Further the contributor (:need:`Contributor <RL_contributor>`) must resolve found issues from the automated checks, if they do not pass.
+A *PR* is reviewed with all content that adds/modifies it. As long as a *PR* requires further work by the contributor (:need:`Contributor <rl_contributor>`), the *PR* is not approved and thus not merged and further changes are requested. Once the contributor (:need:`Contributor <rl_contributor>`) considers all review comments as resolved, :need:`Contributor <rl_contributor>` can re-request a review. The committer (:need:`Committer <rl_committer>`) reviews the *PR* content according the *SCORE* review and acceptance criteria (ToDo link here to the criteria).
+Further the contributor (:need:`Contributor <rl_contributor>`) must resolve found issues from the automated checks, if they do not pass.
 
-As long as the *PR* does not meet the defined criteria and the checks does not pass, it will not be approved. If it does not follow the required templates, based on the provided content or the templates are not filled out properly, the committer as reviewer (:need:`Committer <RL_committer>`) will place the *PR* to the "Draft" state.
+As long as the *PR* does not meet the defined criteria and the checks does not pass, it will not be approved. If it does not follow the required templates, based on the provided content or the templates are not filled out properly, the committer as reviewer (:need:`Committer <rl_committer>`) will place the *PR* to the "Draft" state.
 
-It is then the responsibility of the contributor (:need:`Contributor <RL_contributor>`) to add the missing information and to re-start the contribution by placing the *PR* back for review.
+It is then the responsibility of the contributor (:need:`Contributor <rl_contributor>`) to add the missing information and to re-start the contribution by placing the *PR* back for review.
 
 To change from "Draft" to "Open" see `Changing the stage of a pull request (Github Docs) <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request>`_.
 
-At any point the contributor (:need:`Contributor <RL_contributor>`) may decide not to continue with the PR, then the contributor (:need:`Contributor <RL_contributor>`) just closes the PR.
+At any point the contributor (:need:`Contributor <rl_contributor>`) may decide not to continue with the PR, then the contributor (:need:`Contributor <rl_contributor>`) just closes the PR.
 
 
 What is a GitHub Issue?
 =======================
 
 .. gd_guidl:: Issue Guideline
-  :id: GD_GUIDL__Issue_Guideline
+  :id: gd_guidl__issue_guideline
   :status: valid
   :tags: contribution_management
 

--- a/docs/process/guidance/contribution_request/templates/feature_request_template.rst
+++ b/docs/process/guidance/contribution_request/templates/feature_request_template.rst
@@ -18,7 +18,7 @@ Feature Request Template
 ########################
 
 .. gd_temp:: Feature Request Template
-   :id: GD_TEMP__Feat_Request_Template
+   :id: gd_temp__feat_request_template
    :status: valid
    :tags: contribution_request
 
@@ -31,7 +31,7 @@ Feature Request Template
 .. code-block:: rst
 
    .. document:: [Your Feature Name]
-      :id: DOC__Your_Feature_Name
+      :id: doc__your_feature_name
       :status: Your_Status
       :safety: Your_ASIL
       :tags: contribution_request, feature_request
@@ -93,7 +93,7 @@ Specification
 
    .. note::
       A Feature Request shall specify the stakeholder requirements as part of our platform/project.
-      Thereby the :need:`RL_technical_lead` will approve these requirements as part of accepting the Feature Request (e.g. merging the PR with the Feature Request).
+      Thereby the :need:`rl_technical_lead` will approve these requirements as part of accepting the Feature Request (e.g. merging the PR with the Feature Request).
 
 
 Backwards Compatibility

--- a/docs/process/guidance/requirements/requirement_template.rst
+++ b/docs/process/guidance/requirements/requirement_template.rst
@@ -18,12 +18,12 @@ Requirement Templates
 todo: add links to standards
 
 .. gd_temp:: Stakeholder Requirements Template
-  :id: GD_TEMP__stakeholder_requirements_template
+  :id: gd_temp__stakeholder_requirements_template
   :status: draft
   :tags: requirements_management
 
     | .. stkh_req:: <Title>
-    |    :id: STHK_REQ__<Title>
+    |    :id: sthk_req__<title>
     |    :reqtype: <Functional|Interface|Process|Legal|Non-Functional>
     |    :security: <YES|NO>
     |    :safety: <QM|ASIL_B|ASIL_D>
@@ -32,12 +32,12 @@ todo: add links to standards
 
 
 .. gd_temp:: Feature Requirements Template
-    :id: GD_TEMP__feature_requirements_template
+    :id: gd_temp__feature_requirements_template
     :status: draft
     :tags: safety
 
     | .. feat_req:: <Title>
-    |    :id: FEAT_REQ__<Feature>__<Title>
+    |    :id: feat_req__<feature>__<title>
     |    :reqtype: <Functional|Interface|Process|Legal|Non-Functional>
     |    :security: <YES|NO>
     |    :safety: <QM|ASIL_B|ASIL_D>
@@ -46,12 +46,12 @@ todo: add links to standards
 
 
 .. gd_temp:: Component Requirements Template
-    :id: GD_TEMP__component_requirements_template
+    :id: gd_temp__component_requirements_template
     :status: draft
     :tags: safety
 
     | .. comp_req:: <Title>
-    |    :id: COMP_REQ__<Component>__<Title>
+    |    :id: comp_req__<component>__<title>
     |    :reqtype: <Functional|Interface|Process|Legal|Non-Functional>
     |    :security: <YES|NO>
     |    :safety: <QM|ASIL_B|ASIL_D>
@@ -60,12 +60,12 @@ todo: add links to standards
 
 
 .. gd_temp:: Tool Requirements Template
-  :id: GD_TEMP__tool_requirements_template
+  :id: gd_temp__tool_requirements_template
   :status: draft
   :tags: safety
 
     | .. tool_req:: <Title>
-    |    :id: TOOL_REQ__<Tool>__<Title>
+    |    :id: tool_req__<tool>__<title>
     |    :reqtype: <Functional|Interface|Process|Legal|Non-Functional>
     |    :security: <YES|NO>
     |    :safety: <QM|ASIL_B|ASIL_D>
@@ -74,7 +74,7 @@ todo: add links to standards
 
 
 .. gd_temp:: Requirement Formulation Template
-   :id: GD_TEMP__requirement_formulation
+   :id: gd_temp__requirement_formulation
    :status: valid
    :tags: safety
 

--- a/docs/process/workflows/architecture_design.rst
+++ b/docs/process/workflows/architecture_design.rst
@@ -22,38 +22,38 @@ Workflows
 todo: need to add guidance and standard links
 
 .. workflow:: Create/Maintain Feature architecture
-   :id: WF_CR_MT_FeatArch
+   :id: wf_cr_mt_featarch
    :status: valid
    :tags: architecture_design
-   :responsible: RL_contributor
-   :approved_by: RL_committer
-   :supported_by: RL_safety_manager, RL_security_manager
-   :input: WP_FEATURE_REQ, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_FEATURE_ARCHITECTURE
+   :responsible: rl_contributor
+   :approved_by: rl_committer
+   :supported_by: rl_safety_manager, rl_security_manager
+   :input: wp_feature_req, wp_issue_track_system
+   :output: wp_feature_architecture
 
    | The feature architectures are created and maintained.
 
 .. workflow:: Create/Maintain Components architecture
-   :id: WF_CR_MT_CompArch
+   :id: wf_cr_mt_comparch
    :status: invalid
    :tags: architecture_design
-   :responsible: RL_contributor
-   :approved_by: RL_committer
-   :supported_by: RL_safety_manager, RL_security_manager
-   :input: WP_FEATURE_ARCHITECTURE, WP_SW_COMPONENT_REQ, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_SW_COMPONENT_ARCHITECTURE
+   :responsible: rl_contributor
+   :approved_by: rl_committer
+   :supported_by: rl_safety_manager, rl_security_manager
+   :input: wp_feature_architecture, wp_sw_component_req, wp_issue_track_system
+   :output: wp_sw_component_architecture
 
    | The component architectures are created and maintained.
 
 .. workflow:: Monitor/Verify Architecture
-   :id: WF_MR_VY_Arch
+   :id: wf_mr_vy_arch
    :status: valid
    :tags: architecture_design
-   :responsible: RL_contributor
-   :approved_by: RL_committer
-   :supported_by: RL_safety_manager, RL_security_manager
-   :input: WP_FEATURE_ARCHITECTURE, WP_SW_COMPONENT_ARCHITECTURE
-   :output: WP_ISSUE_TRACK_SYSTEM, WP_SW_ARCH_VERIFICATION
+   :responsible: rl_contributor
+   :approved_by: rl_committer
+   :supported_by: rl_safety_manager, rl_security_manager
+   :input: wp_feature_architecture, wp_sw_component_architecture
+   :output: wp_issue_track_system, wp_sw_arch_verification
 
    | The architecture designs are monitored and verified.
    | The inspection shall be implemented as integral part of the review in GitHub.

--- a/docs/process/workflows/change_management.rst
+++ b/docs/process/workflows/change_management.rst
@@ -22,35 +22,35 @@ Workflows
 todo: need to add standard links
 
 .. workflow:: Create/Discuss Change request
-   :id: WF_CR_DC_ChangeRequest
+   :id: wf_cr_dc_changerequest
    :status: valid
    :tags: change_management
-   :responsible: RL_contributor
-   :approved_by: RL_committer
-   :supported_by: RL_technical_lead, RL_module_lead
-   :input: WP_POLICIES, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_FEAT_REQUEST, WP_ISSUE_TRACK_SYSTEM
-   :contains: GD_GUIDL__Contr_Request_Guideline, GD_GUIDL__Pull_Request_Guideline, GD_GUIDL__Issue_Guideline
+   :responsible: rl_contributor
+   :approved_by: rl_committer
+   :supported_by: rl_technical_lead, rl_module_lead
+   :input: wp_policies, wp_issue_track_system
+   :output: wp_feat_request, wp_issue_track_system
+   :contains: gd_guidl__contr_request_guideline, gd_guidl__pull_request_guideline, gd_guidl__issue_guideline
 
    | The change/contribution request is created and discussed.
    | The request must be filled out based on the existing templates.
    | The possible outcome is a contribution request from type change.
-   | Until the template is not filled out properly, the change request may be kept in "Draft" from the :need:`RL_committer`.
+   | Until the template is not filled out properly, the change request may be kept in "Draft" from the :need:`rl_committer`.
    | The possible outcome is either a change request with status "Draft" or "In Review".
 
 
 .. workflow:: Review/Approve Change request
-   :id: WF_RV_AP_ChangeRequest
+   :id: wf_rv_ap_changerequest
    :status: valid
    :tags: change_management
-   :responsible: RL_committer
-   :approved_by: RL_technical_lead, RL_module_lead
-   :supported_by: RL_safety_manager, RL_security_manager, RL_quality_manager
-   :input: WP_FEAT_REQUEST, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_FEAT_REQUEST, WP_ISSUE_TRACK_SYSTEM
-   :contains: GD_GUIDL__Contr_Request_Guideline, GD_GUIDL__Pull_Request_Guideline, GD_GUIDL__Issue_Guideline
+   :responsible: rl_committer
+   :approved_by: rl_technical_lead, rl_module_lead
+   :supported_by: rl_safety_manager, rl_security_manager, rl_quality_manager
+   :input: wp_feat_request, wp_issue_track_system
+   :output: wp_feat_request, wp_issue_track_system
+   :contains: gd_guidl__contr_request_guideline, gd_guidl__pull_request_guideline, gd_guidl__issue_guideline
 
    | The change/contribution request is reviewed and approved.
-   | The final approval is done by the :need:`RL_technical_lead` or the :need:`RL_module_lead` dependent on scope.
+   | The final approval is done by the :need:`rl_technical_lead` or the :need:`rl_module_lead` dependent on scope.
    | The possible outcome is either a change request with status "Accepted" or "Rejected".
    | Only if the request is accepted, it will be merged.

--- a/docs/process/workflows/platform_management.rst
+++ b/docs/process/workflows/platform_management.rst
@@ -22,14 +22,14 @@ Workflows
 todo: need to add guidance and standard links
 
 .. workflow:: Create/Maintain Platform Management Plan
-   :id: WF_CR_MT_PLATFORM_MNGMT_PLAN
+   :id: wf_cr_mt_platform_mngmt_plan
    :status: draft
    :tags: process
-   :responsible: RL_technical_lead
-   :approved_by: RL_process_community
-   :supported_by: RL_safety_manager, RL_security_manager, RL_quality_manager
-   :input: WP_POLICIES, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_PLATFORM_MGMT
+   :responsible: rl_technical_lead
+   :approved_by: rl_process_community
+   :supported_by: rl_safety_manager, rl_security_manager, rl_quality_manager
+   :input: wp_policies, wp_issue_track_system
+   :output: wp_platform_mgmt
 
    | The Platform Management Plan shall include the Plans for Project and Risk Management, Safety and Quality Management, Release Management, Configuration Management, Change Management, Documentation Management, Problem Resolution, Requirement Management, Tool Management, Stakeholder Management and also the Software Development and Verification Plan.
    | These plans contain the measures for example:
@@ -38,14 +38,14 @@ todo: need to add guidance and standard links
    | - to manage, analyse and control changes of the work products during the project life cycle.
 
 .. workflow:: Monitor/Improve Platform Management Plan
-   :id: WF_MR_VY_PLATFORM_MNGMT_PLAN
+   :id: wf_mr_vy_platform_mngmt_plan
    :status: draft
    :tags: process
-   :responsible: RL_technical_lead
-   :approved_by: RL_process_community
-   :supported_by: RL_safety_manager, RL_security_manager, RL_quality_manager
-   :input: WP_PLATFORM_MGMT
-   :output: WP_ISSUE_TRACK_SYSTEM
+   :responsible: rl_technical_lead
+   :approved_by: rl_process_community
+   :supported_by: rl_safety_manager, rl_security_manager, rl_quality_manager
+   :input: wp_platform_mgmt
+   :output: wp_issue_track_system
 
    | The Project Manager is responsible for the monitoring of the activities against the platform management plan.
    | The Project Manager is responsible to adjust the plan, if deviations are detected.

--- a/docs/process/workflows/process_management.rst
+++ b/docs/process/workflows/process_management.rst
@@ -22,38 +22,38 @@ Workflows
 todo: need to add guidance and standard links
 
 .. workflow:: Create/Maintain Process Management Strategy
-   :id: WF_CR_MT_PROC_MGT_STRATEGY
+   :id: wf_cr_mt_proc_mgt_strategy
    :status: draft
    :tags: process
-   :responsible: RL_process_community
-   :approved_by: RL_project_lead
-   :supported_by: RL_external_assessor
-   :input: WP_POLICIES, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_PROCESS_PLAN
+   :responsible: rl_process_community
+   :approved_by: rl_project_lead
+   :supported_by: rl_external_assessor
+   :input: wp_policies, wp_issue_track_system
+   :output: wp_process_plan
 
    Process management strategy is created and maintained.
    Process metamodel see :ref:`processes_introduction`.
 
 .. workflow:: Define/Approve Process
-   :id: WF_DEF_APP_PROCESS_DEFINTION
+   :id: wf_def_app_process_defintion
    :status: draft
    :tags: process
-   :responsible: RL_process_community
-   :approved_by: RL_technical_lead
-   :supported_by: RL_external_assessor
-   :input: WP_PROCESS_PLAN, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_PROCESS_DEFINITION
+   :responsible: rl_process_community
+   :approved_by: rl_technical_lead
+   :supported_by: rl_external_assessor
+   :input: wp_process_plan, wp_issue_track_system
+   :output: wp_process_definition
 
    Process is defined and approved.
 
 .. workflow:: Monitor/Control Process
-   :id: WF_MON_CTRL_PROCESS_DEFINTION
+   :id: wf_mon_ctrl_process_defintion
    :status: draft
    :tags: process
-   :responsible: RL_process_community
-   :approved_by: RL_technical_lead
-   :supported_by: RL_external_assessor
-   :input: WP_PROCESS_DEFINITION
-   :output: WP_PROCESS_IMPR_REPORT
+   :responsible: rl_process_community
+   :approved_by: rl_technical_lead
+   :supported_by: rl_external_assessor
+   :input: wp_process_definition
+   :output: wp_process_impr_report
 
    Process is monitored and improvements are triggered, if required.

--- a/docs/process/workflows/quality_management.rst
+++ b/docs/process/workflows/quality_management.rst
@@ -22,86 +22,86 @@ Workflows
 todo: need to add guidance and standard links
 
 .. workflow:: Create/Maintain Quality Plan
-   :id: WF_CR_MT_QLM_PLAN
+   :id: wf_cr_mt_qlm_plan
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_POLICIES, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_QMS
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_policies, wp_issue_track_system
+   :output: wp_qms
 
-   | The quality plan is created and maintained by a :need:`RL_committer`.
+   | The quality plan is created and maintained by a :need:`rl_committer`.
 
 .. workflow:: Verify/Approve Platform Release
-   :id: WF_VY_AP_PltRelease
+   :id: wf_vy_ap_pltrelease
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_QMS
-   :output: WP_PLATFORM_SW_RELEASE_NOTE
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_qms
+   :output: wp_platform_sw_release_note
 
    | The project/platform release is verified and approved.
 
 .. workflow:: Execute Platform Process Audit
-   :id: WF_EXE_PltProcess_Audit
+   :id: wf_exe_pltprocess_audit
    :status: draft
    :tags: quality_management
-   :responsible: RL_quality_manager
-   :approved_by: RL_technical_lead
-   :supported_by: RL_safety_manager, RL_security_manager
-   :input: WP_QMS, WP_PROCESS_DEFINITION
-   :output: WP_PROCESS_IMPR_REPORT
+   :responsible: rl_quality_manager
+   :approved_by: rl_technical_lead
+   :supported_by: rl_safety_manager, rl_security_manager
+   :input: wp_qms, wp_process_definition
+   :output: wp_process_impr_report
 
    | The project/platform processes are audited.
 
 .. workflow:: Execute Feature Process Compliance Checks
-   :id: WF_EXE_FeatProcess_Compliance_Checks
+   :id: wf_exe_featprocess_compliance_checks
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_QMS, WP_FEAT_REQUEST, WP_PROCESS_DEFINITION
-   :output: WP_QMS_REPORT
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_qms, wp_feat_request, wp_process_definition
+   :output: wp_qms_report
 
    | The compliance of the feature contribution is checked.
 
 .. workflow:: Execute Feature Work Product Reviews
-   :id: WF_EXE_FeatWP_Review
+   :id: wf_exe_featwp_review
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_QMS, WP_PROCESS_DEFINITION
-   :output: WP_PLATFORM_SW_VERIFICATION_REPORT
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_qms, wp_process_definition
+   :output: wp_platform_sw_verification_report
 
    | The quality of the work products is assured.
 
 .. workflow:: Consult and Execute Quality Trainings
-   :id: WF_CONSULT_EXE_QLY_TRAINING
+   :id: wf_consult_exe_qly_training
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_QMS, WP_POLICIES, WP_PROCESS_DEFINITION
-   :output: WP_TRAINING_PATH
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_qms, wp_policies, wp_process_definition
+   :output: wp_training_path
 
    | The quality manager consults all project/platform stakeholder for quality topics and executes regulary quality trainings.
 
 .. workflow:: Monitor/Improve Quality Activities
-   :id: WF_MR_IMP_QLM_PLAN_PROCESSES
+   :id: wf_mr_imp_qlm_plan_processes
    :status: draft
    :tags: quality_management
-   :responsible: RL_committer
-   :approved_by: RL_quality_manager
-   :supported_by: RL_technical_lead
-   :input: WP_QMS, WP_PLATFORM_SW_RELEASE_NOTE, WP_MODULE_SW_RELEASE_NOTE, WP_PROCESS_IMPR_REPORT, WP_QMS_REPORT, WP_PLATFORM_SW_VERIFICATION_REPORT, WP_MODULE_SW_VERIFICATION_REPORT, WP_TRAINING_PATH
-   :output: WP_ISSUE_TRACK_SYSTEM
+   :responsible: rl_committer
+   :approved_by: rl_quality_manager
+   :supported_by: rl_technical_lead
+   :input: wp_qms, wp_platform_sw_release_note, wp_module_sw_release_note, wp_process_impr_report, wp_qms_report, wp_platform_sw_verification_report, wp_module_sw_verification_report, wp_training_path
+   :output: wp_issue_track_system
 
    | The Quality Manager is responsible for the monitoring of the activities against the quality management plan.
    | The Quality Manager is responsible to adjust the plan, if deviations are detected.

--- a/docs/process/workflows/requirements_management.rst
+++ b/docs/process/workflows/requirements_management.rst
@@ -22,64 +22,64 @@ Workflows
 todo: need to add guidance and standard links
 
 .. workflow:: Create/Maintain Stakeholder requirements
-   :id: WF_create_maintain_stakeholder_requirements
+   :id: wf_create_maintain_stakeholder_requirements
    :status: valid
-   :responsible: RL_contributor
-   :approved_by: RL_technical_lead
-   :supported_by: RL_safety_manager
-   :input: WP_POLICIES, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_STAKEHOLDER_REQ
-   :contains: GD_TEMP__stakeholder_requirements_template, GD_TEMP__requirement_formulation
+   :responsible: rl_contributor
+   :approved_by: rl_technical_lead
+   :supported_by: rl_safety_manager
+   :input: wp_policies, wp_issue_track_system
+   :output: wp_stakeholder_req
+   :contains: gd_temp__stakeholder_requirements_template, gd_temp__requirement_formulation
 
    | Stakeholder requirements can be created during a contribution request. Any contributor can create a stakeholder requirement and propose it for approval.
 
 .. workflow:: Create/Maintain Feature requirements
-   :id: WF_create_maintain_feature_requirements
+   :id: wf_create_maintain_feature_requirements
    :status: valid
    :tags: requirements_management
-   :responsible: RL_contributor
-   :approved_by: RL_technical_lead
-   :supported_by: RL_safety_manager
-   :input: WP_STAKEHOLDER_REQ, WP_ISSUE_TRACK_SYSTEM, WP_FEATURE_SAFETY_ANALYSES, WP_FEATURE_DFA
-   :output: WP_FEATURE_REQ, WP_FEATURE_AOU, WP_PLATFORM_SW_SAFETY_MANUAL
-   :contains: GD_TEMP__feature_requirements_template, GD_TEMP__requirement_formulation
+   :responsible: rl_contributor
+   :approved_by: rl_technical_lead
+   :supported_by: rl_safety_manager
+   :input: wp_stakeholder_req, wp_issue_track_system, wp_feature_safety_analyses, wp_feature_dfa
+   :output: wp_feature_req, wp_feature_aou, wp_platform_sw_safety_manual
+   :contains: gd_temp__feature_requirements_template, gd_temp__requirement_formulation
 
    | Depending on the stakeholder requirements feature requirements can be derived. This can be done by any contributor and will be approved by a contributor. If needed a Safety Manager can provide support.
 
 .. workflow:: Create/Maintain Component requirements
-   :id: WF_create_maintain_component_requirements
+   :id: wf_create_maintain_component_requirements
    :status: valid
    :tags: requirements_management
-   :responsible: RL_contributor
-   :approved_by: RL_committer
-   :supported_by: RL_safety_manager
-   :input: WP_FEATURE_REQ, WP_ISSUE_TRACK_SYSTEM, WP_SW_COMPONENT_SAFETY_ANALYSES, WP_SW_COMPONENT_DFA
-   :output: WP_SW_COMPONENT_REQ, WP_SW_COMPONENT_AOU, WP_MODULE_SW_SAFETY_MANUAL
-   :contains: GD_TEMP__component_requirements_template, GD_TEMP__requirement_formulation
+   :responsible: rl_contributor
+   :approved_by: rl_committer
+   :supported_by: rl_safety_manager
+   :input: wp_feature_req, wp_issue_track_system, wp_sw_component_safety_analyses, wp_sw_component_dfa
+   :output: wp_sw_component_req, wp_sw_component_aou, wp_module_sw_safety_manual
+   :contains: gd_temp__component_requirements_template, gd_temp__requirement_formulation
 
    | On the lowest level the component requirements are created and maintained. This can be done by any contributor and will be approved by a committer. If needed a safety manager can provide support.
 
 .. workflow:: Create/Maintain Tool requirements
-   :id: WF_create_maintain_tool_requirements
+   :id: wf_create_maintain_tool_requirements
    :status: valid
    :tags: requirements_management
-   :responsible: RL_process_community
-   :approved_by: RL_infrastructure_tooling_community
-   :supported_by: RL_safety_manager
-   :input: WP_POLICIES, WP_STAKEHOLDER_REQ, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_TOOL_REQ
-   :contains: GD_TEMP__tool_requirements_template, GD_TEMP__requirement_formulation
+   :responsible: rl_process_community
+   :approved_by: rl_infrastructure_tooling_community
+   :supported_by: rl_safety_manager
+   :input: wp_policies, wp_stakeholder_req, wp_issue_track_system
+   :output: wp_tool_req
+   :contains: gd_temp__tool_requirements_template, gd_temp__requirement_formulation
 
    | The tool requirements are created and maintained.
 
 .. workflow:: Monitor/Verify Requirements
-   :id: WF_monitor_verify_requirements
+   :id: wf_monitor_verify_requirements
    :status: valid
    :tags: requirements_management
-   :responsible: RL_committer
-   :approved_by: RL_committer
-   :supported_by: RL_safety_manager
-   :input: WP_STAKEHOLDER_REQ, WP_TOOL_REQ, WP_FEATURE_REQ, WP_SW_COMPONENT_REQ, WP_FEATURE_AOU, WP_SW_COMPONENT_AOU, WP_PLATFORM_SW_SAFETY_MANUAL, WP_MODULE_SW_SAFETY_MANUAL
-   :output: WP_ISSUE_TRACK_SYSTEM, WP_SW_REQ_INSPECT
+   :responsible: rl_committer
+   :approved_by: rl_committer
+   :supported_by: rl_safety_manager
+   :input: wp_stakeholder_req, wp_tool_req, wp_feature_req, wp_sw_component_req, wp_feature_aou, wp_sw_component_aou, wp_platform_sw_safety_manual, wp_module_sw_safety_manual
+   :output: wp_issue_track_system, wp_sw_req_inspect
 
    | The requirements are monitored and verified. The inspection shall be implemented as integral part of the review in GitHub.

--- a/docs/process/workflows/safety_analysis.rst
+++ b/docs/process/workflows/safety_analysis.rst
@@ -23,38 +23,38 @@ todo: need to add guidance and standard links
 
 
 .. workflow:: Analyse Feature Architecture
-   :id: WF_ANALYSE_FeatArch
+   :id: wf_analyse_featarch
    :status: draft
    :tags: safety_analysis
-   :responsible: RL_committer
-   :approved_by: RL_safety_manager
-   :supported_by: RL_technical_lead, RL_security_manager
-   :input: WP_FEATURE_REQ, WP_FEATURE_ARCHITECTURE, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_FEATURE_SAFETY_ANALYSES, WP_FEATURE_DFA
+   :responsible: rl_committer
+   :approved_by: rl_safety_manager
+   :supported_by: rl_technical_lead, rl_security_manager
+   :input: wp_feature_req, wp_feature_architecture, wp_issue_track_system
+   :output: wp_feature_safety_analyses, wp_feature_dfa
 
    | The safety analysis and DFA for the feature is executed.
 
 .. workflow:: Analyse Component Architecture
-   :id: WF_ANALYSE_CompArch
+   :id: wf_analyse_comparch
    :status: draft
    :tags: safety_analysis
-   :responsible: RL_committer
-   :approved_by: RL_safety_manager
-   :supported_by: RL_module_lead, RL_security_manager
-   :input:  WP_SW_COMPONENT_REQ, WP_SW_COMPONENT_ARCHITECTURE, WP_ISSUE_TRACK_SYSTEM
-   :output: WP_SW_COMPONENT_SAFETY_ANALYSES, WP_SW_COMPONENT_DFA
+   :responsible: rl_committer
+   :approved_by: rl_safety_manager
+   :supported_by: rl_module_lead, rl_security_manager
+   :input:  wp_sw_component_req, wp_sw_component_architecture, wp_issue_track_system
+   :output: wp_sw_component_safety_analyses, wp_sw_component_dfa
 
    | The safety analysis and DFA for the component is executed.
 
 .. workflow:: Monitor/Verify Safety Analyses and DFA
-   :id: WF_MR_VY_SAF_ANALYSES_DFA
+   :id: wf_mr_vy_saf_analyses_dfa
    :status: draft
    :tags: safety_analysis
-   :responsible: RL_committer
-   :approved_by: RL_safety_manager
-   :supported_by: RL_technical_lead, RL_module_lead, RL_security_manager
-   :input: WP_FEATURE_SAFETY_ANALYSES, WP_FEATURE_DFA, WP_SW_COMPONENT_SAFETY_ANALYSES, WP_SW_COMPONENT_DFA
-   :output: WP_SW_ARCH_VERIFICATION, WP_ISSUE_TRACK_SYSTEM
+   :responsible: rl_committer
+   :approved_by: rl_safety_manager
+   :supported_by: rl_technical_lead, rl_module_lead, rl_security_manager
+   :input: wp_feature_safety_analyses, wp_feature_dfa, wp_sw_component_safety_analyses, wp_sw_component_dfa
+   :output: wp_sw_arch_verification, wp_issue_track_system
 
    | The safety analyses and DFA are monitored and verified.
    | The inspection shall be implemented as integral part of the review tool.

--- a/docs/process/workproducts/index.rst
+++ b/docs/process/workproducts/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -33,28 +33,28 @@ General
 ^^^^^^^
 
 .. workproduct:: Policies
-   :id: WP_POLICIES
+   :id: wp_policies
    :status: draft
    :tags: requirements_management
 
    Organization-specific rules and processes for functional safety and cybersecurity.
 
 .. workproduct:: Training path
-   :id: WP_TRAINING_PATH
+   :id: wp_training_path
    :status: draft
    :tags: safety
 
    Evidence of competence management.
 
 .. workproduct:: Quality management system
-   :id: WP_QMS
+   :id: wp_qms
    :status: draft
    :tags: safety
 
    Evidence of quality management.
 
 .. workproduct:: Quality report
-   :id: WP_QMS_REPORT
+   :id: wp_qms_report
    :status: draft
    :tags: safety
 
@@ -66,7 +66,7 @@ General
    | * Identifies any associated measurements using the information
 
 .. workproduct:: Issue tracking system
-   :id: WP_ISSUE_TRACK_SYSTEM
+   :id: wp_issue_track_system
    :status: draft
    :tags: requirements_management, safety_management
 
@@ -80,7 +80,7 @@ General
    | The documentation of a change shall contain the list of changed work products, the details of the change and the planned date of deployment of the change.
 
 .. workproduct:: Feature Request
-   :id: WP_FEAT_REQUEST
+   :id: wp_feat_request
    :status: draft
    :tags: contribution_management, safety_management
 
@@ -88,7 +88,7 @@ General
    | - Change request
 
 .. workproduct:: Platform Management Plan
-   :id: WP_PLATFORM_MGMT
+   :id: wp_platform_mgmt
    :status: draft
    :tags: safety_management
 
@@ -100,7 +100,7 @@ General
    Documentation guideline requirements must be defined for each WP. Each work product or document must include a title, author and approver, unique revision identification, change history, and status.
 
 .. workproduct:: Software Development Plan
-   :id: WP_SW_DEV_PLAN
+   :id: wp_sw_dev_plan
    :status: draft
    :tags: process
 
@@ -120,21 +120,21 @@ Process
 ^^^^^^^
 
 .. workproduct:: Process Definition
-   :id: WP_PROCESS_DEFINITION
+   :id: wp_process_definition
    :status: draft
    :tags: process
 
    Process definitions.
 
 .. workproduct:: Process Improvement Report
-   :id: WP_PROCESS_IMPR_REPORT
+   :id: wp_process_impr_report
    :status: draft
    :tags: process
 
    Process improvement report.
 
 .. workproduct:: Process Management Strategy
-   :id: WP_PROCESS_PLAN
+   :id: wp_process_plan
    :status: draft
    :tags: process
 
@@ -148,35 +148,35 @@ Platform development
 ^^^^^^^^^^^^^^^^^^^^
 
 .. workproduct:: Stakeholder Requirements
-   :id: WP_STAKEHOLDER_REQ
+   :id: wp_stakeholder_req
    :status: draft
    :tags: requirements_management
 
    Technical requirements from a stakeholder viewpoint and Assumptions of use based on the integration as SW platform SEooC in an assumed context.
 
 .. workproduct:: Tool Requirements
-   :id: WP_TOOL_REQ
+   :id: wp_tool_req
    :status: draft
    :tags: requirements_management
 
    SW Requirements for tools to ensure automatic enforcement of rules and as input for software tool qualification.
 
 .. workproduct:: Feature Requirements
-   :id: WP_FEATURE_REQ
+   :id: wp_feature_req
    :status: draft
    :tags: requirements_management
 
    SW Requirements describing in a more detailed way the functionality which will fulfill a set of stakeholder requirements. A "feature" consists of a set of requirements. These feature requirements shall also be the basis for integration testing on platform level.
 
 .. workproduct:: Feature Assumptions of Use
-   :id: WP_FEATURE_AOU
+   :id: wp_feature_aou
    :status: draft
    :tags: safety
 
    SW Safety Requirements for the user of the feature, exportable requirements for the user to integrate in their req mgt system.
 
 .. workproduct:: Feature Architecture
-   :id: WP_FEATURE_ARCHITECTURE
+   :id: wp_feature_architecture
    :status: draft
    :tags: safety
 
@@ -187,7 +187,7 @@ Platform development
    Technical concept on platform level.
 
 .. workproduct:: Feature Safety Analyses
-   :id: WP_FEATURE_SAFETY_ANALYSES
+   :id: wp_feature_safety_analyses
    :status: draft
    :tags: safety
 
@@ -195,7 +195,7 @@ Platform development
    - Detection and prevention mitigations linked to Software Feature Requirements or Assumptions of Use
 
 .. workproduct:: Feature DFA
-   :id: WP_FEATURE_DFA
+   :id: wp_feature_dfa
    :status: draft
    :tags: safety
 
@@ -204,7 +204,7 @@ Platform development
    Perform analysis on interactions between safety related and non-safety related modules or modules with different ASIL of one feature. Including potential influences from the rest of the SW platform.
 
 .. workproduct:: Platform Build Configuration
-   :id: WP_PLATFORM_SW_BUILD_CONFIG
+   :id: wp_platform_sw_build_config
    :status: draft
    :tags: safety
 
@@ -212,7 +212,7 @@ Platform development
    Note: Embedded software in the sense of the Iso (i.e. deployed on the production HW) is not part of our delivery.
 
 .. workproduct:: Feature Integration test
-   :id: WP_FEATURE_INTEGRATION_TEST
+   :id: wp_feature_integration_test
    :status: draft
    :tags: safety
 
@@ -223,14 +223,14 @@ Platform development
    on reference HW
 
 .. workproduct:: Platform test
-   :id: WP_PLATFORM_TEST
+   :id: wp_platform_test
    :status: draft
    :tags: safety
 
    Platform Testing verfies Stakeholder Requirements performed on reference HW
 
 .. workproduct:: Platform Verification Report
-   :id: WP_PLATFORM_SW_VERIFICATION_REPORT
+   :id: wp_platform_sw_verification_report
    :status: draft
    :tags: safety
 
@@ -241,7 +241,7 @@ Platform development
    - Formal evidence about the performed Safety Analyses
 
 .. workproduct:: Platform Release Notes
-   :id: WP_PLATFORM_SW_RELEASE_NOTE
+   :id: wp_platform_sw_release_note
    :status: draft
    :tags: safety_management
 
@@ -252,21 +252,21 @@ Component development
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. workproduct:: Component Requirements
-   :id: WP_SW_COMPONENT_REQ
+   :id: wp_sw_component_req
    :status: draft
    :tags: requirements_management
 
    | SW Requirements for own and OSS qualified components/libraries. QM and ASIL requirements are distinguished by attributes/tags.
 
 .. workproduct:: Component Assumptions of Use
-   :id: WP_SW_COMPONENT_AOU
+   :id: wp_sw_component_aou
    :status: draft
    :tags: safety
 
    SW Safety Requirements for the user of the component, exportable requirements for the user to integrate in their req mgt system.
 
 .. workproduct:: Hardware-software interface (HSI) specification
-   :id: WP_HSI
+   :id: wp_hsi
    :status: draft
    :tags: safety
 
@@ -274,7 +274,7 @@ Component development
    | The HSI specification shall include the component's hardware parts that are controlled by software and hardware resources that support the execution of the software.
 
 .. workproduct:: Requirements Inspection
-   :id: WP_SW_REQ_INSPECT
+   :id: wp_sw_req_inspect
    :status: draft
    :tags: safety
 
@@ -284,7 +284,7 @@ Component development
    | Compare also `Gitub documentationt <https://docs.github.com/en>`_
 
 .. workproduct:: Component Architecture
-   :id: WP_SW_COMPONENT_ARCHITECTURE
+   :id: wp_sw_component_architecture
    :status: draft
    :tags: safety
 
@@ -294,7 +294,7 @@ Component development
    Note: In case no sub-components exist, this can be covered by Detailed Design (in "Implementation" workproduct)
 
 .. workproduct:: Component Safety Analyses
-   :id: WP_SW_COMPONENT_SAFETY_ANALYSES
+   :id: wp_sw_component_safety_analyses
    :status: draft
    :tags: safety
 
@@ -302,7 +302,7 @@ Component development
    - Detection and prevention mitigations linked to Software Component Requirements or Assumptions of Use
 
 .. workproduct:: Component DFA
-   :id: WP_SW_COMPONENT_DFA
+   :id: wp_sw_component_dfa
    :status: draft
    :tags: safety
 
@@ -312,7 +312,7 @@ Component development
    Perform analysis on interactions between safety related and non-safety related sub-components or sub-components with different ASIL of one component. Including potential influences from the other components in the component's module.
 
 .. workproduct:: Architecture Verification
-   :id: WP_SW_ARCH_VERIFICATION
+   :id: wp_sw_arch_verification
    :status: draft
    :tags: safety
 
@@ -320,7 +320,7 @@ Component development
    May include several methods like inspection, modelling ... Which are selected in SW Development Plan.
 
 .. workproduct:: Implementation
-   :id: WP_SW_IMPLEMENTATION
+   :id: wp_sw_implementation
    :status: draft
    :tags: safety
 
@@ -328,21 +328,21 @@ Component development
    The "how to" is described in the SW Development Plan guidelines
 
 .. workproduct:: Unit test
-   :id: WP_SW_UNIT_TEST
+   :id: wp_sw_unit_test
    :status: draft
    :tags: safety
 
    Unit testing verifies component requirements and detailed design (traced to). Tooling defined in SW Development Plan and integrated in CI/Build.
 
 .. workproduct:: Code Inspection
-   :id: WP_SW_CODE_INSPECT
+   :id: wp_sw_code_inspect
    :status: draft
    :tags: safety
 
    github review with integrated inspection checklist (includes manual checking of coding guidelines)
 
 .. workproduct:: Module Verification Report
-   :id: WP_MODULE_SW_VERIFICATION_REPORT
+   :id: wp_module_sw_verification_report
    :status: draft
    :tags: safety
 
@@ -356,7 +356,7 @@ Component development
    - Software component qualification verification report
 
 .. workproduct:: Component Integration test
-   :id: WP_SW_COMPONENT_INTEGRATION_TEST
+   :id: wp_sw_component_integration_test
    :status: draft
    :tags: safety
 
@@ -366,7 +366,7 @@ Component development
    performance: i.e. RAM and processor usage on reference HW
 
 .. workproduct:: Module Build Configuration
-   :id: WP_MODULE_SW_BUILD_CONFIG
+   :id: wp_module_sw_build_config
    :status: draft
    :tags: safety
 
@@ -374,7 +374,7 @@ Component development
    Note: Embedded software in the sense of the Iso (i.e. deployed on the production HW) is not part of our delivery.
 
 .. workproduct:: Module Release Notes
-   :id: WP_MODULE_SW_RELEASE_NOTE
+   :id: wp_module_sw_release_note
    :status: draft
    :tags: safety_management
 
@@ -382,7 +382,7 @@ Component development
 
 
 .. workproduct:: Component test
-   :id: WP_SW_COMPONENT_TEST
+   :id: wp_sw_component_test
    :status: draft
    :tags: safety
 
@@ -393,14 +393,14 @@ Supporting activities
 ---------------------
 
 .. workproduct:: Verification Plan
-   :id: WP_VERIFICATION_PLAN
+   :id: wp_verification_plan
    :status: draft
    :tags: process, safety
 
    Verification planning for each phase of the safety lifecycle must detail the work products, objectives, methods, criteria, environments, equipment, resources, actions for anomalies, and regression strategies, considering method adequacy, complexity, prior experiences, and technology maturity or risks.
 
 .. workproduct:: Verification Specification
-   :id: WP_VERIFICATION_SPEC
+   :id: wp_verification_spec
    :status: draft
    :tags: process, safety
 
@@ -408,7 +408,7 @@ Supporting activities
    Test cases, test data, and test objects are part of the respective test WPs.
 
 .. workproduct:: Software tool criteria evaluation report
-   :id: WP_TOOL_EVAL
+   :id: wp_tool_eval
    :status: draft
    :tags: process, safety
 

--- a/docs/requirements/stakeholder/index.rst
+++ b/docs/requirements/stakeholder/index.rst
@@ -21,7 +21,7 @@ Overall goals
 -------------
 
 .. stkh_req:: Reuse of application software via managed APIs
-   :id: STKH_REQ__20
+   :id: stkh_req__20
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -34,7 +34,7 @@ Overall goals
 
 
 .. stkh_req:: Enable cooperation via standardized APIs
-    :id: STKH_REQ__30
+    :id: stkh_req__30
     :reqtype: Non-Functional
     :security: NO
     :safety: QM
@@ -44,7 +44,7 @@ Overall goals
     The software platform shall where possible be based on existing standards (e.g. network protocols).
 
 .. stkh_req:: Variant management
-    :id: STKH_REQ__60
+    :id: stkh_req__60
     :reqtype: Functional
     :security: NO
     :safety: QM
@@ -58,7 +58,7 @@ Overall goals
 
 
 .. stkh_req:: IP protection
-   :id: STKH_REQ__50
+   :id: stkh_req__50
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -75,7 +75,7 @@ Functional requirements
 -----------------------
 
 .. stkh_req:: File Based Configuration
-   :id: STKH_REQ__8
+   :id: stkh_req__8
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -85,7 +85,7 @@ Functional requirements
    The platform shall support configuration of applications via files (e.g. yaml, json)
 
 .. stkh_req:: Support of safe Key/Value store
-   :id: STKH_REQ__350
+   :id: stkh_req__350
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -98,7 +98,7 @@ Functional requirements
    Note: This is part of 0.1 release and therefore can only support ASIL_B. Goal is ASIL_D.
 
 .. stkh_req:: Safe Configuration
-   :id: STKH_REQ__9
+   :id: stkh_req__9
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -110,7 +110,7 @@ Functional requirements
 
 
 .. stkh_req:: Safe Computation
-   :id: STKH_REQ__10
+   :id: stkh_req__10
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -121,7 +121,7 @@ Functional requirements
 
 
 .. stkh_req:: Hardware Accelerated Computation
-   :id: STKH_REQ__11
+   :id: stkh_req__11
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -132,7 +132,7 @@ Functional requirements
 
 
 .. stkh_req:: Data Persistency
-   :id: STKH_REQ__12
+   :id: stkh_req__12
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -143,7 +143,7 @@ Functional requirements
 
 
 .. stkh_req:: Operating System
-   :id: STKH_REQ__13
+   :id: stkh_req__13
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -153,7 +153,7 @@ Functional requirements
    The platform shall support operating systems compliant with IEEE Std 1003.1 (2004 Edition or newer)
 
 .. stkh_req:: Video subsystem
-   :id: STKH_REQ__340
+   :id: stkh_req__340
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -172,7 +172,7 @@ Functional requirements
 
 
 .. stkh_req:: Compute subsystem
-   :id: STKH_REQ__330
+   :id: stkh_req__330
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -194,7 +194,7 @@ Functional requirements
      * GSML serialized data
 
 .. stkh_req:: Communication with external MCUs/standby controllers
-   :id: STKH_REQ__310
+   :id: stkh_req__310
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -215,7 +215,7 @@ Dependability
 -------------
 
 .. stkh_req:: Automotive Safety Integrity Level
-   :id: STKH_REQ__70
+   :id: stkh_req__70
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -229,7 +229,7 @@ Dependability
 
 
 .. stkh_req:: Safety features
-   :id: STKH_REQ__80
+   :id: stkh_req__80
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -252,7 +252,7 @@ Dependability
 
 
 .. stkh_req:: Availability
-   :id: STKH_REQ__90
+   :id: stkh_req__90
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -264,7 +264,7 @@ Dependability
 
 
 .. stkh_req:: Security features
-   :id: STKH_REQ__140
+   :id: stkh_req__140
    :reqtype: Functional
    :security: YES
    :safety: QM
@@ -320,7 +320,7 @@ interaction)** — each emphasize different operational priorities.
 
 
 .. stkh_req:: Support for Time-based Architectures
-   :id: STKH_REQ__281
+   :id: stkh_req__281
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -332,7 +332,7 @@ interaction)** — each emphasize different operational priorities.
 
 
 .. stkh_req:: Support for Data-driven Architecture
-   :id: STKH_REQ__282
+   :id: stkh_req__282
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -342,7 +342,7 @@ interaction)** — each emphasize different operational priorities.
    The platform shall support an event-driven, high-throughput application architecture where execution is triggered by data changes.
 
 .. stkh_req:: Support for Request-driven Architecture
-   :id: STKH_REQ__283
+   :id: stkh_req__283
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -357,7 +357,7 @@ Execution model
 ---------------
 
 .. stkh_req:: Processes and thread management
-   :id: STKH_REQ__280
+   :id: stkh_req__280
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -380,7 +380,7 @@ Execution model
      * signal handling, error handling (FPU Exceptions, other traps …)
 
 .. stkh_req:: Short application cycles
-   :id: STKH_REQ__110
+   :id: stkh_req__110
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -391,7 +391,7 @@ Execution model
    platform assumed this is supported by the underlying hardware.
 
 .. stkh_req:: Realtime capabilities
-   :id: STKH_REQ__111
+   :id: stkh_req__111
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -402,7 +402,7 @@ Execution model
    (timing events, interrupts) within a defined timing interval.
 
 .. stkh_req:: Startup performance
-   :id: STKH_REQ__112
+   :id: stkh_req__112
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -413,7 +413,7 @@ Execution model
    resume from hibernate mode.
 
 .. stkh_req:: Low power mode
-   :id: STKH_REQ__113
+   :id: stkh_req__113
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -426,7 +426,7 @@ Communication
 -------------
 
 .. stkh_req:: Inter-process Communication
-   :id: STKH_REQ__2
+   :id: stkh_req__2
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -437,7 +437,7 @@ Communication
 
 
 .. stkh_req:: Intra-process Communication
-   :id: STKH_REQ__3
+   :id: stkh_req__3
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -447,7 +447,7 @@ Communication
    The platform shall support intra-process communication.
 
 .. stkh_req:: Stable application interfaces
-   :id: STKH_REQ__171
+   :id: stkh_req__171
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -458,7 +458,7 @@ Communication
    external interfaces to keep application interfaces stable.
 
 .. stkh_req:: Extensible External Communication
-   :id: STKH_REQ__5
+   :id: stkh_req__5
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -469,7 +469,7 @@ Communication
 
 
 .. stkh_req:: Safe Communication
-   :id: STKH_REQ__6
+   :id: stkh_req__6
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -480,7 +480,7 @@ Communication
 
 
 .. stkh_req:: Secure Communication
-   :id: STKH_REQ__7
+   :id: stkh_req__7
    :reqtype: Functional
    :security: YES
    :safety: QM
@@ -490,7 +490,7 @@ Communication
    The platform shall support secure communication.
 
 .. stkh_req:: Supported network protocols
-   :id: STKH_REQ__160
+   :id: stkh_req__160
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -509,7 +509,7 @@ Communication
 
 
 .. stkh_req:: Quality of service
-   :id: STKH_REQ__170
+   :id: stkh_req__170
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -526,7 +526,7 @@ Communication
 
 
 .. stkh_req:: Automotive diagnostics
-   :id: STKH_REQ__180
+   :id: stkh_req__180
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -543,7 +543,7 @@ Hardware support
 ----------------
 
 .. stkh_req:: Chipset support for ARM64 and x64
-   :id: STKH_REQ__190
+   :id: stkh_req__190
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -554,7 +554,7 @@ Hardware support
 
 
 .. stkh_req:: Virtualization support for debug and testing
-   :id: STKH_REQ__200
+   :id: stkh_req__200
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -566,7 +566,7 @@ Hardware support
 
 
 .. stkh_req:: Support of container technologies
-   :id: STKH_REQ__210
+   :id: stkh_req__210
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -585,7 +585,7 @@ Developer experience
 --------------------
 
 .. stkh_req:: IDL Support
-   :id: STKH_REQ__220
+   :id: stkh_req__220
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -597,7 +597,7 @@ Developer experience
 
 
 .. stkh_req:: Developer experience and development toolchain
-   :id: STKH_REQ__230
+   :id: stkh_req__230
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -616,7 +616,7 @@ Developer experience
 
 
 .. stkh_req:: Performance analysis
-   :id: STKH_REQ__240
+   :id: stkh_req__240
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -630,7 +630,7 @@ Developer experience
    * RAM usage statistics for long-term Memory behavior
 
 .. stkh_req:: Tracing of execution
-   :id: STKH_REQ__241
+   :id: stkh_req__241
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -638,7 +638,7 @@ Developer experience
    :status: valid
 
    The platform shall support the tracing of events (start, stop) of executable
-   entities and kernel threads on all computation units e.g. 
+   entities and kernel threads on all computation units e.g.
 
    * CPU
    * GPU
@@ -647,7 +647,7 @@ Developer experience
    * etc.
 
 .. stkh_req:: Tracing of communication
-   :id: STKH_REQ__242
+   :id: stkh_req__242
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -658,7 +658,7 @@ Developer experience
    and external communication systems.
 
 .. stkh_req:: Tracing of memory access
-   :id: STKH_REQ__243
+   :id: stkh_req__243
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -666,13 +666,13 @@ Developer experience
    :status: valid
 
    The platform shall support the tracing of memory events (allocation, copy,
-   de-allocation) for different types of memory e.g. 
+   de-allocation) for different types of memory e.g.
 
    * CPU Memory
    * GPU Memory
 
 .. stkh_req:: Timing analysis
-   :id: STKH_REQ__120
+   :id: stkh_req__120
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -683,7 +683,7 @@ Developer experience
    timing requirements with state-of-the-art analysis tools.
 
 .. stkh_req:: Debugging
-   :id: STKH_REQ__250
+   :id: stkh_req__250
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -695,7 +695,7 @@ Developer experience
 
 
 .. stkh_req:: Programming languages for application development
-   :id: STKH_REQ__260
+   :id: stkh_req__260
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -711,7 +711,7 @@ Developer experience
 
 
 .. stkh_req:: Reprocessing and simulation support
-   :id: STKH_REQ__270
+   :id: stkh_req__270
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -722,7 +722,7 @@ Developer experience
 
 
 .. stkh_req:: Logging support
-   :id: STKH_REQ__290
+   :id: stkh_req__290
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -739,7 +739,7 @@ Developer experience
    * Logging of early startup events
 
 .. stkh_req:: Previous boot logging
-   :id: STKH_REQ__291
+   :id: stkh_req__291
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -755,7 +755,7 @@ Integration
 -----------
 
 .. stkh_req:: Multirepo integration
-   :id: STKH_REQ__INT_multi_repo_integration
+   :id: stkh_req__int_multi_repo_integration
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -769,7 +769,7 @@ Quality
 -------
 
 .. stkh_req:: Document assumptions and design decisions
-   :id: STKH_REQ__QLY_document_assumptions_and_design_decisions
+   :id: stkh_req__qly_document_assumptions_and_design_decisions
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -783,7 +783,7 @@ Requirements Engineering
 ------------------------
 
 .. stkh_req:: Requirements traceability
-   :id: STKH_REQ__RE_requirements_traceability
+   :id: stkh_req__re_requirements_traceability
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -793,7 +793,7 @@ Requirements Engineering
    All requirements shall be linked from lower to upper level, whereby the top-level are the stakeholder requirements.
 
 .. stkh_req:: Document requirements as code
-   :id: STKH_REQ__RE_requirements_as_code
+   :id: stkh_req__re_requirements_as_code
    :reqtype: Non-Functional
    :security: NO
    :safety: QM

--- a/docs/requirements/tool/index.rst
+++ b/docs/requirements/tool/index.rst
@@ -23,11 +23,11 @@ Integration tools
 
 
 .. tool_req:: Bazel for unified build, test and integration
-   :id: TOOL_REQ__BAZEL__unified_build_test_integration
+   :id: tool_req__bazel__unified_build_test_integration
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__INT_multi_repo_integration
+   :satisfies: stkh_req__int_multi_repo_integration
    :status: valid
 
    Bazel shall be used for building, testing and integrating software.
@@ -38,11 +38,11 @@ Process tools
 
 
 .. tool_req:: Sphinx-needs for process modelling
-   :id: TOOL_REQ__Sphinx-needs__Process_Modelling
+   :id: tool_req__sphinx-needs__process_modelling
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: STKH_REQ__RE_requirements_as_code
+   :satisfies: stkh_req__re_requirements_as_code
    :status: valid
 
    Spinx-needs shall be used to model all processes within SCORE.


### PR DESCRIPTION
Replace all ids and options items by their value in small letters.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

I used 2 regex to do the job (:[a-z]*: .*__.*) and (:[a-z]*: .*_.*)  and replaced them with \L$1 all using VS Code option to search and replace regex patterns to handle all options and id cases that not follow the pattern.
In another PR we will handle the case of id and options that start only with one "_" Plus there were some small mistakes like changing ASIL_D/B to asil_d/b and some small unnecessary ones that I fixed manually by returning them to their old value.
 
Related to: #282 