### PR TITLE
tooling: Correct Stakeholders' requirements ids to be meaningful.

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/checks/id_contains_feature.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/id_contains_feature.py
@@ -12,8 +12,8 @@
 # *******************************************************************************
 import os
 
-from sphinx_needs.data import NeedsInfoType
 from sphinx.application import Sphinx
+from sphinx_needs.data import NeedsInfoType
 
 from score_metamodel import (
     CheckLogger,
@@ -31,7 +31,7 @@ def id_contains_feature(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
 
     parts = need["id"].split("__")
 
-    if len(parts) != 3:
+    if len(parts) != 3 or need["id"].startswith("stkh_req__"):
         # No warning needed here, as this is already checked in the metamodel.
         return
 

--- a/docs/_tooling/extensions/score_metamodel/checks/id_format_and_length.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/id_format_and_length.py
@@ -28,9 +28,7 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     # Split the string by underscores
     parts = need["id"].split("__")
 
-    if need["id"].startswith(
-        ("gd_", "wf__", "wp__", "rl__", "stkh_req__", "tool_req__", "doc__")
-    ):
+    if need["id"].startswith(("gd_", "wf__", "wp__", "rl__", "tool_req__", "doc__")):
         if len(parts) != 2 and len(parts) != 3:
             msg = "expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`."
             log.warning_for_option(need, "id", msg)

--- a/docs/_tooling/extensions/score_metamodel/checks/traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/traceability.py
@@ -25,9 +25,8 @@ def check_linkage_parent(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogg
     # Convert list to dictionary for easy lookup
     needs_dict = {need["id"]: need for need in needs}
 
-    parents_not_correct = []
-
     for need in needs:
+        parents_not_correct = []
         for satisfie_need in need.get("satisfies", []):
             if needs_dict.get(satisfie_need, {}).get("status") != "valid":
                 parents_not_correct.append(satisfie_need)

--- a/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
@@ -92,12 +92,12 @@ class TestTraceability:
             status="valid",
             safety="QM",
             satisfies=[
-                "stkh_req__3",
+                "stkh_req__communication__intra_process",
             ],
         )
 
         need_3 = tests.need(
-            id="stkh_req__3",
+            id="stkh_req__communication__intra_process",
             status="valid",
             safety="QM",
         )
@@ -114,12 +114,12 @@ class TestTraceability:
             id="feat_req__1",
             safety="ASIL_D",
             satisfies=[
-                "stkh_req__2",
+                "stkh_req__communication__inter_process",
             ],
         )
 
         need_2 = tests.need(
-            id="stkh_req__2",
+            id="stkh_req__communication__inter_process",
             status="valid",
             safety="ASIL_B",
         )
@@ -141,12 +141,12 @@ class TestTraceability:
             id="feat_req__1",
             safety="ASIL_B",
             satisfies=[
-                "stkh_req__2",
+                "stkh_req__communication__inter_process",
             ],
         )
 
         need_2 = tests.need(
-            id="stkh_req__2",
+            id="stkh_req__communication__inter_process",
             safety="QM",
         )
         needs = [need_1, need_2]

--- a/docs/features/communication/ipc/index.rst
+++ b/docs/features/communication/ipc/index.rst
@@ -250,7 +250,7 @@ This includes error handling, which shall follow one of the error handling conce
 1. :need:`feat_req__ipc__lang_idioms`
 2. :need:`feat_req__ipc__lang_infra`
 
-Since S-CORE supports multiple programming languages (see :need:`stkh_req__260`), this leads to multiple APIs that might
+Since S-CORE supports multiple programming languages (see :need:`stkh_req__dev_experience__prog_languages`), this leads to multiple APIs that might
 diverge significantly from each other, but provide the same feature set to the user.
 To support something like this, without reimplementing the full communication stack in both languages, an abstraction
 layer within the communication framework is unavoidable.
@@ -309,9 +309,9 @@ Bindings are specified in the deployment configuration.
 
 Some possible bindings are:
 
-- IPC  (see :need:`stkh_req__2`)
-- SOME/IP (see :need:`stkh_req__160`)
-- DDS (see :need:`stkh_req__160`)
+- IPC  (see :need:`stkh_req__communication__inter_process`)
+- SOME/IP (see :need:`stkh_req__communication__supported_net`)
+- DDS (see :need:`stkh_req__communication__supported_net`)
 - fake binding (for testing)
 
 Dynamic deployment at runtime
@@ -329,7 +329,7 @@ This information is enriched through a runtime `Service discovery`.
 Tracing
 -------
 
-Based on :need:`stkh_req__242` the communication framework must support tracing of communication events.
+Based on :need:`stkh_req__dev_experience__tracing_of_comm` the communication framework must support tracing of communication events.
 In a framework with multiple bindings, this requires a zero-copy binding-agnostic tracing solution in the abstraction
 layer.
 

--- a/docs/features/communication/ipc/requirements/index.rst
+++ b/docs/features/communication/ipc/requirements/index.rst
@@ -23,7 +23,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__281
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_time
    :status: valid
 
    The communication framework shall provide API to support a time-based architecture.
@@ -33,7 +33,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__282
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_data
    :status: valid
 
    The communication framework shall provide API to support a data-driven architecture.
@@ -43,7 +43,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__282
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_data
    :status: valid
 
    The communication framework shall provide API to support a request-driven architecture.
@@ -53,7 +53,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2,stkh_req__282,stkh_req__283
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_data,stkh_req__app_architectures__support_request
    :status: valid
 
    A communication interface consists of a combination of any number of the following elements:
@@ -67,7 +67,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__282
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_data
    :status: valid
 
    An event-type is part of a communication interface and has:
@@ -83,7 +83,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__283
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_request
    :status: valid
 
    A method is part of a communication interface and has:
@@ -103,7 +103,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__281
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_time
    :status: valid
 
    A signal is part of a communication interface and has:
@@ -125,7 +125,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2,stkh_req__281
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_time
    :status: valid
 
    Communication shall be cached based on the producer-consumer pattern.
@@ -135,7 +135,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    A communication interface that is offered to consumers is called a service instance.
@@ -147,7 +147,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    A service instance is offered under one or more unique names by which it can be discovered.
@@ -162,7 +162,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support versioning of service instances.
@@ -177,7 +177,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The interface to access service instances is agnostic to the binding used to communicate with the service.
@@ -188,7 +188,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support stateless communication.
@@ -201,7 +201,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support multiple service instances per software architecture element.
@@ -212,7 +212,7 @@ High cohesion and loose coupling
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall provide service discovery to find available services during runtime.
@@ -228,7 +228,7 @@ Mixed-Criticality safety systems
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support safe communication involving communication partners on the same or multiple
@@ -239,7 +239,7 @@ Mixed-Criticality safety systems
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    Consumers with lower criticality shall not be able to corrupt data consumed by partners with higher criticality.
@@ -249,7 +249,7 @@ Mixed-Criticality safety systems
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    Consumers with lower criticality shall not be able to modify the order of data consumed by partners with higher
@@ -260,7 +260,7 @@ Mixed-Criticality safety systems
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    Consumers with lower criticality shall not be able to duplicate data consumed by other communication partners with
@@ -271,7 +271,7 @@ Mixed-Criticality safety systems
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    Consumers with lower criticality shall not be able to drop data before it is consumed by partners with higher
@@ -285,7 +285,7 @@ Performance
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2,stkh_req__282
+   :satisfies: stkh_req__communication__inter_process,stkh_req__app_architectures__support_data
    :status: valid
 
    IPC communication shall be possible without copying to-be-transferred data.
@@ -298,7 +298,7 @@ User friendly API for information exchange
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__260
+   :satisfies: stkh_req__dev_experience__prog_languages
    :status: valid
 
    The communication framework shall provide a public API for each supported programming language of SCORE.
@@ -308,7 +308,7 @@ User friendly API for information exchange
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__260
+   :satisfies: stkh_req__dev_experience__prog_languages
    :status: valid
 
    Each public API shall support the idioms of the programming language it is written in.
@@ -318,7 +318,7 @@ User friendly API for information exchange
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__260
+   :satisfies: stkh_req__dev_experience__prog_languages
    :status: valid
 
    Each public API shall use core infrastructure of its programming language and accompanying standard libraries,
@@ -334,7 +334,7 @@ Full testability for the user facing API
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The public API shall be fully mockable.
@@ -344,7 +344,7 @@ Full testability for the user facing API
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall provide a fake binding.
@@ -357,7 +357,7 @@ Multi-binding support
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support multiple bindings.
@@ -371,7 +371,7 @@ Multi-binding support
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The public API of the communication framework shall be binding-agnostic.
@@ -385,7 +385,7 @@ Multi-binding support
    :reqtype: Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The association of a service instance and the appropriate binding shall be specified in the deployment configuration.
@@ -398,7 +398,7 @@ Dynamic deployment at runtime
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    Deployment configuration shall be read from an integrity-checked configuration file at runtime.
@@ -411,7 +411,7 @@ Tracing
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
-   :satisfies: stkh_req__242
+   :satisfies: stkh_req__dev_experience__tracing_of_comm
    :status: valid
 
    The communication framework shall provide infrastructure to enable binding-agnostic, zero-copy, read-only tracing of
@@ -425,7 +425,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support an Access Control Lists in the deployment configuration.
@@ -435,7 +435,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support an Access Control List per service instance.
@@ -445,7 +445,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support an Access Control List for the communication partner offering a service
@@ -457,7 +457,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support an Access Control List for the communication partner consuming a service
@@ -469,7 +469,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The IPC binding shall ensure confidentiality of its communication.
@@ -479,7 +479,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The IPC binding shall ensure integrity of its communication.
@@ -489,7 +489,7 @@ Security Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
@@ -503,7 +503,7 @@ Safety Impact
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :satisfies: stkh_req__2
+   :satisfies: stkh_req__communication__inter_process
    :status: valid
 
    The communication framework shall support safe communication up to ASIL-B.

--- a/docs/requirements/stakeholder/index.rst
+++ b/docs/requirements/stakeholder/index.rst
@@ -21,7 +21,7 @@ Overall goals
 -------------
 
 .. stkh_req:: Reuse of application software via managed APIs
-   :id: stkh_req__20
+   :id: stkh_req__overall_goals__reuse_of_app_soft
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -34,7 +34,7 @@ Overall goals
 
 
 .. stkh_req:: Enable cooperation via standardized APIs
-    :id: stkh_req__30
+    :id: stkh_req__overall_goals__enable_cooperation
     :reqtype: Non-Functional
     :security: NO
     :safety: QM
@@ -44,7 +44,7 @@ Overall goals
     The software platform shall where possible be based on existing standards (e.g. network protocols).
 
 .. stkh_req:: Variant management
-    :id: stkh_req__60
+    :id: stkh_req__overall_goals__variant_management
     :reqtype: Functional
     :security: NO
     :safety: QM
@@ -58,7 +58,7 @@ Overall goals
 
 
 .. stkh_req:: IP protection
-   :id: stkh_req__50
+   :id: stkh_req__overall_goals__ip_protection
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -75,7 +75,7 @@ Functional requirements
 -----------------------
 
 .. stkh_req:: File Based Configuration
-   :id: stkh_req__8
+   :id: stkh_req__functional_req__file_based
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -85,7 +85,7 @@ Functional requirements
    The platform shall support configuration of applications via files (e.g. yaml, json)
 
 .. stkh_req:: Support of safe Key/Value store
-   :id: stkh_req__350
+   :id: stkh_req__functiona_req__support_of_store
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -98,7 +98,7 @@ Functional requirements
    Note: This is part of 0.1 release and therefore can only support ASIL_B. Goal is ASIL_D.
 
 .. stkh_req:: Safe Configuration
-   :id: stkh_req__9
+   :id: stkh_req__functional_req__safe_config
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -110,7 +110,7 @@ Functional requirements
 
 
 .. stkh_req:: Safe Computation
-   :id: stkh_req__10
+   :id: stkh_req__functional_req__safe_comput
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -121,7 +121,7 @@ Functional requirements
 
 
 .. stkh_req:: Hardware Accelerated Computation
-   :id: stkh_req__11
+   :id: stkh_req__functional_req__hardware_comput
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -132,7 +132,7 @@ Functional requirements
 
 
 .. stkh_req:: Data Persistency
-   :id: stkh_req__12
+   :id: stkh_req__functional_req__data_persistency
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -143,7 +143,7 @@ Functional requirements
 
 
 .. stkh_req:: Operating System
-   :id: stkh_req__13
+   :id: stkh_req__functional_req__operating_system
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -153,7 +153,7 @@ Functional requirements
    The platform shall support operating systems compliant with IEEE Std 1003.1 (2004 Edition or newer)
 
 .. stkh_req:: Video subsystem
-   :id: stkh_req__340
+   :id: stkh_req__functional_req__video_subsystem
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -172,7 +172,7 @@ Functional requirements
 
 
 .. stkh_req:: Compute subsystem
-   :id: stkh_req__330
+   :id: stkh_req__functional_req__comp_subsystem
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -194,7 +194,7 @@ Functional requirements
      * GSML serialized data
 
 .. stkh_req:: Communication with external MCUs/standby controllers
-   :id: stkh_req__310
+   :id: stkh_req__functional_req__comm_with_control
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -215,7 +215,7 @@ Dependability
 -------------
 
 .. stkh_req:: Automotive Safety Integrity Level
-   :id: stkh_req__70
+   :id: stkh_req__dependability__automotive_safety
    :reqtype: Functional
    :security: NO
    :safety: ASIL_B
@@ -229,7 +229,7 @@ Dependability
 
 
 .. stkh_req:: Safety features
-   :id: stkh_req__80
+   :id: stkh_req__dependability__safety_features
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -252,7 +252,7 @@ Dependability
 
 
 .. stkh_req:: Availability
-   :id: stkh_req__90
+   :id: stkh_req__dependability__availability
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -264,7 +264,7 @@ Dependability
 
 
 .. stkh_req:: Security features
-   :id: stkh_req__140
+   :id: stkh_req__dependability__security_features
    :reqtype: Functional
    :security: YES
    :safety: QM
@@ -320,7 +320,7 @@ interaction)** — each emphasize different operational priorities.
 
 
 .. stkh_req:: Support for Time-based Architectures
-   :id: stkh_req__281
+   :id: stkh_req__app_architectures__support_time
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -332,7 +332,7 @@ interaction)** — each emphasize different operational priorities.
 
 
 .. stkh_req:: Support for Data-driven Architecture
-   :id: stkh_req__282
+   :id: stkh_req__app_architectures__support_data
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -342,7 +342,7 @@ interaction)** — each emphasize different operational priorities.
    The platform shall support an event-driven, high-throughput application architecture where execution is triggered by data changes.
 
 .. stkh_req:: Support for Request-driven Architecture
-   :id: stkh_req__283
+   :id: stkh_req__app_architectures__support_request
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -357,7 +357,7 @@ Execution model
 ---------------
 
 .. stkh_req:: Processes and thread management
-   :id: stkh_req__280
+   :id: stkh_req__execution_model__processes
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -380,7 +380,7 @@ Execution model
      * signal handling, error handling (FPU Exceptions, other traps …)
 
 .. stkh_req:: Short application cycles
-   :id: stkh_req__110
+   :id: stkh_req__execution_model__short_app_cycles
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -391,7 +391,7 @@ Execution model
    platform assumed this is supported by the underlying hardware.
 
 .. stkh_req:: Realtime capabilities
-   :id: stkh_req__111
+   :id: stkh_req__execution_model__realtime_cap
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -402,7 +402,7 @@ Execution model
    (timing events, interrupts) within a defined timing interval.
 
 .. stkh_req:: Startup performance
-   :id: stkh_req__112
+   :id: stkh_req__execution_model__startup_perf
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -413,7 +413,7 @@ Execution model
    resume from hibernate mode.
 
 .. stkh_req:: Low power mode
-   :id: stkh_req__113
+   :id: stkh_req__execution_model__low_power
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -426,7 +426,7 @@ Communication
 -------------
 
 .. stkh_req:: Inter-process Communication
-   :id: stkh_req__2
+   :id: stkh_req__communication__inter_process
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -437,7 +437,7 @@ Communication
 
 
 .. stkh_req:: Intra-process Communication
-   :id: stkh_req__3
+   :id: stkh_req__communication__intra_process
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -447,7 +447,7 @@ Communication
    The platform shall support intra-process communication.
 
 .. stkh_req:: Stable application interfaces
-   :id: stkh_req__171
+   :id: stkh_req__communication__stable_app_inter
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -458,7 +458,7 @@ Communication
    external interfaces to keep application interfaces stable.
 
 .. stkh_req:: Extensible External Communication
-   :id: stkh_req__5
+   :id: stkh_req__communication__extensible_external
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -469,7 +469,7 @@ Communication
 
 
 .. stkh_req:: Safe Communication
-   :id: stkh_req__6
+   :id: stkh_req__communication__safe
    :reqtype: Functional
    :security: NO
    :safety: ASIL_D
@@ -480,7 +480,7 @@ Communication
 
 
 .. stkh_req:: Secure Communication
-   :id: stkh_req__7
+   :id: stkh_req__communication__secure
    :reqtype: Functional
    :security: YES
    :safety: QM
@@ -490,7 +490,7 @@ Communication
    The platform shall support secure communication.
 
 .. stkh_req:: Supported network protocols
-   :id: stkh_req__160
+   :id: stkh_req__communication__supported_net
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -509,7 +509,7 @@ Communication
 
 
 .. stkh_req:: Quality of service
-   :id: stkh_req__170
+   :id: stkh_req__communication__service_quality
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -526,7 +526,7 @@ Communication
 
 
 .. stkh_req:: Automotive diagnostics
-   :id: stkh_req__180
+   :id: stkh_req__communication__auto_diagnostics
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -543,7 +543,7 @@ Hardware support
 ----------------
 
 .. stkh_req:: Chipset support for ARM64 and x64
-   :id: stkh_req__190
+   :id: stkh_req__hardware_support__chipset_support
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -554,7 +554,7 @@ Hardware support
 
 
 .. stkh_req:: Virtualization support for debug and testing
-   :id: stkh_req__200
+   :id: stkh_req__hardware_support__debug_and_test
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -566,7 +566,7 @@ Hardware support
 
 
 .. stkh_req:: Support of container technologies
-   :id: stkh_req__210
+   :id: stkh_req__hardware_support__container_tech
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -585,7 +585,7 @@ Developer experience
 --------------------
 
 .. stkh_req:: IDL Support
-   :id: stkh_req__220
+   :id: stkh_req__dev_experience__idl_support
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -597,7 +597,7 @@ Developer experience
 
 
 .. stkh_req:: Developer experience and development toolchain
-   :id: stkh_req__230
+   :id: stkh_req__dev_experience__dev_toolchain
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -616,7 +616,7 @@ Developer experience
 
 
 .. stkh_req:: Performance analysis
-   :id: stkh_req__240
+   :id: stkh_req__dev_experience__perf_analysis
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -630,7 +630,7 @@ Developer experience
    * RAM usage statistics for long-term Memory behavior
 
 .. stkh_req:: Tracing of execution
-   :id: stkh_req__241
+   :id: stkh_req__dev_experience__tracing_of_exec
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -647,7 +647,7 @@ Developer experience
    * etc.
 
 .. stkh_req:: Tracing of communication
-   :id: stkh_req__242
+   :id: stkh_req__dev_experience__tracing_of_comm
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -658,7 +658,7 @@ Developer experience
    and external communication systems.
 
 .. stkh_req:: Tracing of memory access
-   :id: stkh_req__243
+   :id: stkh_req__dev_experience__tracing_of_memory
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -672,7 +672,7 @@ Developer experience
    * GPU Memory
 
 .. stkh_req:: Timing analysis
-   :id: stkh_req__120
+   :id: stkh_req__dev_experience__timing_analysis
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -683,7 +683,7 @@ Developer experience
    timing requirements with state-of-the-art analysis tools.
 
 .. stkh_req:: Debugging
-   :id: stkh_req__250
+   :id: stkh_req__dev_experience__debugging
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -695,7 +695,7 @@ Developer experience
 
 
 .. stkh_req:: Programming languages for application development
-   :id: stkh_req__260
+   :id: stkh_req__dev_experience__prog_languages
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -703,7 +703,7 @@ Developer experience
    :status: valid
 
    The platform shall support implementation of applications in the following
-   programming languages up to the highest ASIL level as defined in :need:`stkh_req__70`:
+   programming languages up to the highest ASIL level as defined in :need:`stkh_req__dependability__automotive_safety`:
 
    * C
    * C++
@@ -711,7 +711,7 @@ Developer experience
 
 
 .. stkh_req:: Reprocessing and simulation support
-   :id: stkh_req__270
+   :id: stkh_req__dev_experience__reprocessing
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -722,7 +722,7 @@ Developer experience
 
 
 .. stkh_req:: Logging support
-   :id: stkh_req__290
+   :id: stkh_req__dev_experience__logging_support
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -739,7 +739,7 @@ Developer experience
    * Logging of early startup events
 
 .. stkh_req:: Previous boot logging
-   :id: stkh_req__291
+   :id: stkh_req__dev_experience__boot_logging
    :reqtype: Functional
    :security: NO
    :safety: QM
@@ -755,7 +755,7 @@ Integration
 -----------
 
 .. stkh_req:: Multirepo integration
-   :id: stkh_req__int_multi_repo_integration
+   :id: stkh_req__integration__multi_repo
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -769,7 +769,7 @@ Quality
 -------
 
 .. stkh_req:: Document assumptions and design decisions
-   :id: stkh_req__qly_assumptions_and_dd
+   :id: stkh_req__quality__assumptions_and_dd
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -783,7 +783,7 @@ Requirements Engineering
 ------------------------
 
 .. stkh_req:: Requirements traceability
-   :id: stkh_req__re_requirements_traceability
+   :id: stkh_req__re_requirements__traceability
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
@@ -793,7 +793,7 @@ Requirements Engineering
    All requirements shall be linked from lower to upper level, whereby the top-level are the stakeholder requirements.
 
 .. stkh_req:: Document requirements as code
-   :id: stkh_req__re_requirements_as_code
+   :id: stkh_req__requirements__as_code
    :reqtype: Non-Functional
    :security: NO
    :safety: QM

--- a/docs/requirements/tool/index.rst
+++ b/docs/requirements/tool/index.rst
@@ -27,7 +27,7 @@ Integration tools
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__int_multi_repo_integration
+   :satisfies: stkh_req__integration__multi_repo
    :status: valid
 
    Bazel shall be used for building, testing and integrating software.
@@ -42,7 +42,7 @@ Process tools
    :reqtype: Non-Functional
    :security: NO
    :safety: QM
-   :satisfies: stkh_req__re_requirements_as_code
+   :satisfies: stkh_req__requirements__as_code
    :status: valid
 
    Spinx-needs shall be used to model all processes within SCORE.


### PR DESCRIPTION
Replace all IDs of stakeholders requirements that include numbers with meaningful IDs.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

Related to: #282 