### PR TITLE
docs: Build docs only for main branch and PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize] # Handles forked PRs
   push:
+    branches:
+      - main # docs are built only on push to main branch, for feature branches there are PR builds
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
# Bugfix


## Description

Removed building docs from feature branches in CI. Docs are only build for main branch and PRs.

## Related ticket

closes [#412] (bugfix ticket)