### PR TITLE
dash: enable automatic license clearance via review action

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -47,6 +47,13 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.9.1
+      - name: Derive project shortname and repo URL
+        run: |
+          # Convert slash to dot for the Dash shortname
+          SHORTNAME=$(echo "${GITHUB_REPOSITORY}" | tr '/' '.')
+          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          echo "SHORTNAME=$SHORTNAME" >> $GITHUB_ENV
+          echo "REPO_URL=$REPO_URL" >> $GITHUB_ENV
       - name: Run license checks
         run: |
           # The bash script won't fail on error. We capture the stderr and stdout and we save
@@ -54,7 +61,12 @@ jobs:
           # The output will also be stored in a file using the tee command
           # We save both  output and exit code in the GH actions env file
           set +e  # Ensure script does not exit on failure, even if the bazel run fails, the execution will continue
-          OUTPUT=$(bazel run //:license.check.python 2>&1)
+          OUTPUT=$(
+            bazel run //docs:license.check.python --define=CI_BUILD=true -- \
+              -project "$SHORTNAME" \
+              -repo "$REPO_URL" \
+              -token "${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}" 2>&1
+          )
           EXIT_CODE=$?
           echo "$OUTPUT" | tee license-check-output.txt
           echo "exit_code=$EXIT_CODE" >> $GITHUB_ENV

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -46,6 +46,14 @@ load("@rules_python//sphinxdocs:sphinx.bzl", "sphinx_build_binary", "sphinx_docs
 load("//tools/dash:dash.bzl", "dash_license_checker")
 load("//tools/testing/pytest:defs.bzl", "score_py_pytest")
 
+config_setting(
+    name = "ci_build",
+    values = {
+        # Matches when user passes --define=CI_BUILD=true
+        "define": "CI_BUILD=true",
+    },
+)
+
 sphinx_requirements = all_requirements + [
     "@rules_python//python/runfiles",
     ":plantuml_for_python",

--- a/tools/dash/dash.bzl
+++ b/tools/dash/dash.bzl
@@ -47,7 +47,17 @@ def dash_license_checker(
         runtime_deps = [
             "@dash_license_tool//jar",
         ],
-        args = ["$(location :{}2dash)".format(name)],
+        # We'll build up "args" in the order: [ static options ] + select() + [ file last ]
+        args = [
+            # If we have any always-on flags, put them here
+        ] + select({
+            # If CI_BUILD=true, add "-review"
+            ":ci_build": ["-review"],
+            "//conditions:default": [],
+        }) + [
+            # The file is last
+            "$(location :{}2dash)".format(name),
+        ],
         data = [
             ":{}2dash".format(name),
         ],


### PR DESCRIPTION
Enabled the execution of `review` for the dash tool in the CI pipeline. This won't work on local development unless developers have their own DASH PATs. Important notice:  secrets remain in the CI workflow, not in Bazel BUILD files, they won't be exposed.

Fixes: #348