### PR TITLE
dash: issue calling DASH API

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -49,9 +49,9 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.9.1
       - name: Derive project shortname and repo URL
         run: |
-          # Convert slash to dot for the Dash shortname
-          SHORTNAME=$(echo "${GITHUB_REPOSITORY}" | tr '/' '.')
-          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git"
+          # Use a fixed shortname for the Dash project
+          SHORTNAME="eclipse-score"
+          REPO_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           echo "SHORTNAME=$SHORTNAME" >> $GITHUB_ENV
           echo "REPO_URL=$REPO_URL" >> $GITHUB_ENV
       - name: Run license checks


### PR DESCRIPTION
It appears there are some issues with the call

```
INFO: Running command line: bazel-bin/docs/license.check.python docs/formatted.txt -review -project eclipse-score.score -repo https://github.com/eclipse-score/score.git -token ***
Exception in thread "main" java.lang.RuntimeException: org.eclipse.dash.api.EclipseApi: An error occurred while calling the API.
	at org.eclipse.dash.api.EclipseApi.getApiData(EclipseApi.java:174)
	at org.eclipse.dash.api.EclipseApi.getProject(EclipseApi.java:127)
	at org.eclipse.dash.licenses.validation.EclipseProjectIdValidator.validate(EclipseProjectIdValidator.java:31)
	at org.eclipse.dash.licenses.cli.Main.main(Main.java:78)
```
Tried looking into the code and this is the line failing:

```java
		if (result == 400 || result == 404) {
			// FIXME As of December 2024, we get a 400 (Bad Request) error when we ask
			// for a project that does not exist. There may be other things that cause a
			// error 400; for now, though, we assume that a 400 means "Not Found".
			// See https://gitlab.eclipse.org/eclipsefdn/it/websites/projects.eclipse.org/-/issues/381
			return JsonValue.EMPTY_JSON_OBJECT;
		}

```

The  helpdesk ticket originally mentioned:

>> A GitLab bot user for the eclipse-score project (username: score-bot) and an API token have been created.
>>The API token has been added to eclipse-score organization as organization secret (ID: ECLIPSE_GITLAB_API_TOKEN)

So it might be that the problem relies in the project name.

Fixes: #349