### PR TITLE
dash:  comment wasn't posted

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -75,7 +75,7 @@ jobs:
           echo "$OUTPUT" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
       - name: Comment on PR with License Check Results
-        if: github.event_name == 'pull_request'
+        if: github.event.pull_request
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
```
if: github.event.pull_request
```
Above condition has to be used to cover both `pull_request` and `pull_request_target` Since `pull_request_target` also includes `github.event.pull_request`, the condition will evaluate to true when triggered by a PR.

Fixes: #349