### PR TITLE
docs: Remove ruff&pyright current suppresions

### DIFF
--- a/docs/_tooling/extensions/score_draw_uml_funcs/__init__.py
+++ b/docs/_tooling/extensions/score_draw_uml_funcs/__init__.py
@@ -30,8 +30,8 @@ import time
 from functools import cache
 from pathlib import Path
 
-from sphinx.application import Sphinx  # type: ignore
-from sphinx_needs.logging import get_logger  # type: ignore
+from sphinx.application import Sphinx
+from sphinx_needs.logging import get_logger
 
 from score_draw_uml_funcs.helpers import (
     find_interfaces_of_operations,

--- a/docs/_tooling/extensions/score_plantuml.py
+++ b/docs/_tooling/extensions/score_plantuml.py
@@ -27,11 +27,11 @@ In addition it sets common PlantUML options, like output to svg_obj.
 import sys
 from pathlib import Path
 
-from sphinx.application import Sphinx  # type: ignore
-from sphinx.util import logging  # type: ignore
+from sphinx.application import Sphinx
+from sphinx.util import logging
 
 try:
-    from python.runfiles import Runfiles  # type: ignore
+    from python.runfiles import Runfiles
 except ImportError:
     sys.exit(
         "ERROR: This script must be run from within the virtual environment "

--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -13,9 +13,9 @@
 import json
 from copy import deepcopy
 
-from sphinx.application import Sphinx  # type: ignore
-from sphinx_needs.data import SphinxNeedsData  # type: ignore
-from sphinx_needs.logging import get_logger  # type: ignore
+from sphinx.application import Sphinx
+from sphinx_needs.data import SphinxNeedsData
+from sphinx_needs.logging import get_logger
 
 from score_source_code_linker.parse_source_files import GITHUB_BASE_URL
 

--- a/docs/_tooling/extensions/score_source_code_linker/tests/test_requirement_links.py
+++ b/docs/_tooling/extensions/score_source_code_linker/tests/test_requirement_links.py
@@ -12,7 +12,7 @@
 # *******************************************************************************
 from collections import defaultdict
 
-import pytest  # type: ignore
+import pytest
 from score_source_code_linker.parse_source_files import (
     GITHUB_BASE_URL,
     extract_requirements,

--- a/docs/_tooling/extensions/score_source_code_linker/tests/test_source_link.py
+++ b/docs/_tooling/extensions/score_source_code_linker/tests/test_source_link.py
@@ -13,10 +13,10 @@
 import json
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 from score_source_code_linker.parse_source_files import GITHUB_BASE_URL
-from sphinx.testing.util import SphinxTestApp  # type: ignore
-from sphinx_needs.data import SphinxNeedsData  # type: ignore
+from sphinx.testing.util import SphinxTestApp
+from sphinx_needs.data import SphinxNeedsData
 
 
 @pytest.fixture(scope="session")

--- a/docs/_tooling/live_preview.py
+++ b/docs/_tooling/live_preview.py
@@ -12,7 +12,7 @@
 # *******************************************************************************
 import os
 
-from sphinx_autobuild.__main__ import main as sphinx_autobuild_main  # type: ignore
+from sphinx_autobuild.__main__ import main as sphinx_autobuild_main
 
 # sphinx will print relative paths to the current directory.
 # Change to the workspace root so that the paths are readable and clickable.

--- a/tools/testing/pytest/main.py
+++ b/tools/testing/pytest/main.py
@@ -16,4 +16,4 @@ import pytest
 
 if __name__ == "__main__":
     args = sys.argv[1:]
-    sys.exit(pytest.main(args))  # type: ignore[attr-defined]
+    sys.exit(pytest.main(args))


### PR DESCRIPTION
# Improvement

## Description

Remove sphinx & pytest `# type: ignore `suppresions. These were wrongfully added.
Selecting the right interpreter fixes the warnings instead.

## Related ticket


related #531  (improvement ticket)