### PR TITLE
tooling: Link and create checks for guidance process requirements

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -101,12 +101,22 @@ def load_metamodel_data():
     with open(yaml_path, "r", encoding="utf-8") as f:
         data = yaml.load(f)
 
+    # Access the custom validation block
+    prohibited_words_dict = data.get("needs_types_base_options", {}).get(
+        "prohibited_words", {}
+    )
+
     types_dict = data.get("needs_types", {})
     links_dict = data.get("needs_extra_links", {})
     graph_check_dict = data.get("graph_checks", {})
 
     global_base_options = data.get("needs_types_base_options", {})
     global_base_options_optional_opts = global_base_options.get("optional_options", {})
+
+    # Get the list of stop-words and weak-words
+    # Get the stop_words and weak_words as separate lists
+    stop_words_list = prohibited_words_dict.get("title", [])
+    weak_words_list = prohibited_words_dict.get("content", [])
 
     # Default options by sphinx, sphinx-needs or anything else we need to account for
     default_options_list = default_options()
@@ -168,6 +178,8 @@ def load_metamodel_data():
     needs_extra_options = sorted(all_options - set(default_options_list))
 
     return {
+        "stop_words": stop_words_list,
+        "weak_words": weak_words_list,
         "needs_types": needs_types_list,
         "needs_extra_links": needs_extra_links_list,
         "needs_extra_options": needs_extra_options,
@@ -228,6 +240,8 @@ def setup(app: Sphinx):
     app.config.needs_extra_links = metamodel["needs_extra_links"]
     app.config.needs_extra_options = metamodel["needs_extra_options"]
     app.config.graph_checks = metamodel["needs_graph_check"]
+    app.config.stop_words = metamodel["stop_words"]
+    app.config.weak_words = metamodel["weak_words"]
 
     discover_checks()
 

--- a/docs/_tooling/extensions/score_metamodel/checks/attributes_format.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/attributes_format.py
@@ -10,7 +10,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-import os
 
 from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
@@ -18,6 +17,7 @@ from sphinx_needs.data import NeedsInfoType
 from score_metamodel import CheckLogger, local_check
 
 
+# req-Id: gd_req__req__attr_uid
 @local_check
 def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     """
@@ -50,3 +50,43 @@ def check_id_length(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     if len(need["id"]) > 45:
         msg = f"exceeds the maximum allowed length of 45 characters (current length: {len(need['id'])})."
         log.warning_for_option(need, "id", msg)
+
+
+# req-Id: gd_req__requirements_attr_title
+@local_check
+def check_title(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
+    """
+    Ensures that the requirement Title does not contain stop words.
+    This helps enforce clear and concise naming conventions.
+    """
+    stop_words = app.config.stop_words
+    if need["type"] in ["stkh_req", "feat_req", "comp_req"]:
+        for word in stop_words:
+            if word in need["title"]:
+                msg = (
+                    f"contains a stop word: `{word}`. The title is meant to provide a short summary, "
+                    "not to repeat the requirement statement. Please revise the title for clarity and brevity."
+                )
+                log.warning_for_option(need, "title", msg)
+                break
+
+
+# req-Id: gd_req__req__attr_desc_weak
+@local_check
+def check_description(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
+    """
+    Ensures that the requirement Description does not contain weak words.
+    This helps enforce strong, clear, and unambiguous requirement phrasing
+    ---
+    """
+    weak_words = app.config.weak_words
+    if need["type"] in [
+        "stkh_req",
+        "feat_req",
+        "comp_req",
+    ] and need.get("content", None):
+        for word in weak_words:
+            if word in need["content"]:
+                msg = f"contains a weak word: `{word}`. Please revise the description."
+                log.warning_for_option(need, "content", msg)
+                break

--- a/docs/_tooling/extensions/score_metamodel/checks/check_options.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/check_options.py
@@ -30,6 +30,49 @@ def get_need_type(needs_types: list[NeedsInfoType], directive: str):
     raise ValueError(f"Need type {directive} not found in needs_types")
 
 
+def validate_fields(
+    need: NeedsInfoType,
+    log: CheckLogger,
+    fields: dict[str, str],
+    required: bool,
+    field_type: str,
+):
+    """
+    Validates that fields (options or links) in a need match their expected patterns.
+
+    :param need: The need object containing the data.
+    :param log: Logger for warnings.
+    :param fields: A dictionary of field names and their regex patterns.
+    :param required: Whether the fields are required (True) or optional (False).
+    :param field_type: A string indicating the field type ('option' or 'link').
+    """
+    for field, pattern in fields.items():
+        values = need.get(field, None)
+
+        if required and (values is None or values in [[], ""]):
+            log.warning_for_need(need, f"is missing required {field_type}: `{field}`.")
+            continue
+
+        if values is None or values in [[], ""]:
+            continue  # Skip optional empty fields
+
+        if not isinstance(values, list):
+            values = [values]
+
+        for value in values:
+            assert isinstance(value, str)
+            if not re.match(pattern, value):
+                log.warning_for_option(
+                    need, field, f"does not follow pattern `{pattern}`."
+                )
+
+
+# req-Id: gd_req__req__attr_type
+# req-Id: gd_req__requirements_attr_security
+# req-Id: gd_req__req__attr_safety
+# req-Id: gd_req__req__attr_status
+# req-Id: gd_req__req__attr_rationale
+# req-Id: gd_req__req__attr_mandatory
 @local_check
 def check_options(
     app: Sphinx,
@@ -38,80 +81,42 @@ def check_options(
     needs_types: list[NeedsInfoType] = None,
 ):
     """
-    Checking if all described and wanted attributes are present and their values follow the described pattern.
+    Checks that required and optional options and links are present and follow their defined patterns.
     """
     production_needs_types = app.config.needs_types
     if not needs_types:
         needs_types = production_needs_types
+
     try:
         need_options = get_need_type(needs_types, need["type"])
     except ValueError:
-        msg = "no type info defined for semantic check."
-        log.warning_for_option(need, "type", msg)
+        log.warning_for_option(need, "type", "no type info defined for semantic check.")
         return
 
-    required_options: dict[str, str] = need_options.get("mandatory_options", {})
-    optional_options: dict[str, str] = need_options.get("opt_opt", {})
+    if not need_options.get("mandatory_options", {}):
+        log.warning_for_option(need, "type", "no type info defined for semantic check.")
 
-    if len(required_options) == 0:
-        msg = "no type info defined for semantic check."
-        log.warning_for_option(need, "type", msg)
+    # Validate Options and Links
+    checking_dict = {
+        "option": [
+            (need_options.get("mandatory_options", {}), True),
+            (need_options.get("opt_opt", {}), False),
+        ],
+        "link": [
+            (dict(need_options.get("req_link", [])), True),
+            #    (dict(need_options.get("opt_link", [])), False),
+        ],
+    }
 
-    for option, pattern in required_options.items():
-        values = need.get(option, None)
-
-        if values is None or values in [[], ""]:
-            msg = f"is missing required option: `{option}`."
-            log.warning_for_need(need, msg)
-            continue
-
-        # Normalize values (list or string)
-        if not isinstance(values, list):
-            values = [values]
-
-        for value in values:
-            assert isinstance(value, str)
-            regex = re.compile(pattern)
-
-            if not regex.match(value):
-                msg = f"does not follow pattern `{pattern}`."
-                log.warning_for_option(need, option, msg)
-
-    for option, pattern in optional_options.items():
-        values = need.get(option, None)
-
-        if values is None or values in [[], ""]:  # Skip if empty
-            continue
-
-        if not isinstance(values, list):
-            values = [values]
-
-        for value in values:
-            assert isinstance(value, str)
-            regex = re.compile(pattern)
-
-            if not regex.match(value):
-                msg = f"does not follow pattern `{pattern}`."
-                log.warning_for_option(need, option, msg)
-
-    required_links: list[tuple[str, str]] = need_options.get("req_link", [])
-    if required_links:
-        for link, pattern in required_links:
-            values = need.get(link, None)
-            if values is None or values in [[], ""]:
-                msg = f"is missing required link: `{link}`."
-                log.warning_for_need(need, msg)
-                continue
-
-            if not isinstance(values, list):
-                values = [values]
-
-            for value in values:
-                assert isinstance(value, str)
-                regex = re.compile(pattern)
-                if not regex.match(value):
-                    msg = f"does not follow pattern `{pattern}`."
-                    log.warning_for_option(need, link, msg)
+    for field_type, check_fields in checking_dict.items():
+        for field_values, is_required in check_fields:
+            validate_fields(
+                need,
+                log,
+                field_values,
+                required=is_required,
+                field_type=field_type,
+            )
 
 
 @local_check

--- a/docs/_tooling/extensions/score_metamodel/checks/standards.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/standards.py
@@ -24,18 +24,7 @@ def get_standards_needs(needs: list[NeedsInfoType]) -> dict:
     Return a dictionary of all standard requirements from the Sphinx app's needs.
     """
 
-    return {
-        need["id"]: need
-        for need in needs
-        if need["id"].startswith(
-            (
-                "std_req__iso26262__",
-                "std_req__iso21434",
-                "std_req__isopas8926",
-                "std_req__aspice_40",
-            )
-        )
-    }
+    return {need["id"]: need for need in needs if need["type"] == "std_req"}
 
 
 def get_standards_workproducts(needs: list[NeedsInfoType]) -> dict:
@@ -43,18 +32,7 @@ def get_standards_workproducts(needs: list[NeedsInfoType]) -> dict:
     Return a dictionary of standard workproducts from the Sphinx app's needs.
     """
 
-    return {
-        need["id"]: need
-        for need in needs
-        if need["id"].startswith(
-            (
-                "std_wp__iso26262__",
-                "std_wp__iso21434",
-                "std_wp__isopas8926",
-                "std_wp__aspice_40",
-            )
-        )
-    }
+    return {need["id"]: need for need in needs if need["type"] == "std_wp"}
 
 
 def get_workflows(needs: list[NeedsInfoType]) -> dict:

--- a/docs/_tooling/extensions/score_metamodel/metamodel.yaml
+++ b/docs/_tooling/extensions/score_metamodel/metamodel.yaml
@@ -15,6 +15,19 @@
 needs_types_base_options:
   optional_options:
     source_code_link: "^https://github.com/eclipse-score/score/blob/.*$"
+  # Custom semantic validation rules
+  prohibited_words:
+    title:
+      - shall
+      - must
+      - will
+    content:
+      - just
+      - about
+      - really
+      - some
+      - thing
+      - absolutely
 
 needs_types:
 
@@ -144,6 +157,10 @@ needs_types:
     optional_options:
       safety: "^(QM|ASIL_B|ASIL_D)$"
       realizes: "^wp__.+$"
+  # The following 3 guidance requirements enforce the requirement structure and attributes:
+  # req-Id: gd_req__req__structure
+  # req-Id: gd_req__requirements_attr_description
+  # req-Id: gd_req__req__linkage
   # Requirements
   stkh_req:
     title: "Stakeholder Requirement"
@@ -162,7 +179,6 @@ needs_types:
       testcovered: "^(YES|NO)$"
       hash: "^.*$"
 
-
   feat_req:
     title: "Feature Requirement"
     prefix: "feat_req__"
@@ -174,6 +190,7 @@ needs_types:
       safety: "^(QM|ASIL_B|ASIL_D)$"
       status: "^(valid|invalid)$"
     mandatory_links:
+      # req-Id: gd_req__req__linkage_fulfill
       satisfies: "^stkh_req__.*$"
     optional_options:
       codelink: "^.*$"
@@ -478,6 +495,8 @@ needs_extra_links:
 #   - condition: defines the condition that should be checked
 #     - [and / or / xor / not]
 ##############################################################
+# req-Id: gd_req__req__linkage_architecture
+# req-Id: gd_req__req__linkage_safety
 graph_checks:
   comp_req_safety:
     needs:
@@ -504,3 +523,7 @@ graph_checks:
           - "status == valid"
     check:
       satisfies: "status == valid"
+      fulfils:
+        and:
+          - "safety != QM"
+          - "status == valid"

--- a/docs/_tooling/extensions/score_metamodel/tests/test_check_options.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_check_options.py
@@ -55,6 +55,32 @@ class TestCheckOptions:
         }
     ]
 
+    NEED_TYPE_INFO_WITH_REQ_LINK = [
+        {
+            "directive": "workflow",
+            "mandatory_options": {
+                "id": "wf__.*$",
+                "status": "^(valid|draft)$",
+            },
+            "req_link": [
+                ("input", "^wp__.*$"),
+            ],
+        }
+    ]
+
+    NEED_TYPE_INFO_WITH_OPT_LINK = [
+        {
+            "directive": "workflow",
+            "mandatory_options": {
+                "id": "wf__.*$",
+                "status": "^(valid|draft)$",
+            },
+            "opt_link": [
+                ("supported_by", "^rl__.*$"),
+            ],
+        }
+    ]
+
     def test_known_directive_with_mandatory_option_and_allowed_value(self):
         # Given a need with a type that is listed in the required options
         #  and mandatory options present
@@ -234,3 +260,50 @@ class TestCheckOptions:
             f'does not follow pattern `{self.NEED_TYPE_INFO_WITH_OPT_OPT[0]["opt_opt"]["some_optional_option"]}`.',
             expect_location=False,
         )
+
+    def test_known_required_link_missing(self):
+        # Given a need without an option that is listed in the required options
+        need = NeedsInfoType(
+            target_id="wf__p_confirm_rv",
+            id="wf__p_confirm_rv",
+            status="valid",
+            type="workflow",
+            docname=None,
+            lineno=None,
+        )
+
+        logger = fake_check_logger()
+        app = Mock(spec=Sphinx)
+        app.config = Mock()
+        app.config.needs_types = self.NEED_TYPE_INFO
+        # Expect that the checks fail and a warning is logged
+        check_options(app, need, logger, self.NEED_TYPE_INFO_WITH_REQ_LINK)
+        logger.assert_warning(
+            "is missing required link: `input`.",
+            expect_location=False,
+        )
+
+    # TODO: Remove commented code when re
+
+    # def test_value_violates_pattern_for_optional_link(self):
+    #     # Given a need without an option that is listed in the required options
+    #     need = NeedsInfoType(
+    #         target_id="wf__p_confirm_rv",
+    #         id="wf__p_confirm_rv",
+    #         status="valid",
+    #         type="workflow",
+    #         supported_by="rl_process_community",
+    #         docname=None,
+    #         lineno=None,
+    #     )
+
+    #     logger = fake_check_logger()
+    #     app = Mock(spec=Sphinx)
+    #     app.config = Mock()
+    #     app.config.needs_types = self.NEED_TYPE_INFO
+    #     # Expect that the checks fail and a warning is logged
+    #     check_options(app, need, logger, self.NEED_TYPE_INFO_WITH_OPT_LINK)
+    #     logger.assert_warning(
+    #         "does not follow pattern",
+    #         expect_location=False,
+    #     )

--- a/docs/_tooling/extensions/score_metamodel/tests/test_id_contains_feature.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_id_contains_feature.py
@@ -24,7 +24,7 @@ def test_feature_ok():
     app = Mock(spec=Sphinx)
 
     id_contains_feature(
-        app, need(id="Req__feature17__Title", docname="path/to/feature17/index"), logger
+        app, need(id="req__feature17__title", docname="path/to/feature17/index"), logger
     )
     logger._log.warning.assert_not_called()
 
@@ -34,6 +34,6 @@ def test_feature_not_ok():
     app = Mock(spec=Sphinx)
 
     id_contains_feature(
-        app, need(id="Req__feature17__Title", docname="path/to/feature15/index"), logger
+        app, need(id="req__feature17__title", docname="path/to/feature15/index"), logger
     )
     logger.assert_warning("feature15", expect_location=False)

--- a/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
@@ -32,6 +32,7 @@ class TestStandards:
     #        need_1 = NeedsInfoType(
     #            target_id="Traceability of safety requirements",
     #            id="std_req__iso26262__rq-8-6432",
+    #            type="std_req",
     #            reqtype="Functional",
     #            status="valid",
     #            docname=None,
@@ -40,7 +41,7 @@ class TestStandards:
     #
     #        need_2 = NeedsInfoType(
     #            target_id="Requirements attribute satisfies",
-    #            id="GD_REQ__attribute_satisfies",
+    #            id="gd_req__attribute_satisfies",
     #            tags="attribute",
     #            security="NO",
     #            type="gd_req",
@@ -50,7 +51,7 @@ class TestStandards:
     #            ],
     #            status="valid",
     #            satisfies=[
-    #             "GD__create_maintain_requirements",
+    #             "gd_req__create_maintain_requirements",
     #         ],
     #         docname=None,
     #         lineno=None,
@@ -74,6 +75,7 @@ class TestStandards:
     #     need_1 = NeedsInfoType(
     #         target_id="Traceability of safety requirements",
     #         id="std_req__iso26262__rq-8-6432",
+    #         type="std_req",
     #         reqtype="Functional",
     #         status="valid",
     #         docname=None,
@@ -82,7 +84,7 @@ class TestStandards:
 
     #     need_2 = NeedsInfoType(
     #         target_id="Requirements attribute satisfies",
-    #         id="GD_REQ__attribute_satisfies",
+    #         id="gd_req__attribute_satisfies",
     #         type="gd_req",
     #         tags="attribute",
     #         security="NO",
@@ -92,7 +94,7 @@ class TestStandards:
     #         ],
     #         status="valid",
     #         satisfies=[
-    #             "GD__create_maintain_requirements",
+    #             "gd_req__create_maintain_requirements",
     #         ],
     #         docname=None,
     #         lineno=None,
@@ -121,6 +123,7 @@ class TestStandards:
     #     need_1 = NeedsInfoType(
     #         target_id="Organization-specific rules and processes for functional safety",
     #         id="std_wp__iso26262__wp-2-551",
+    #         type="std_wp",
     #         status="valid",
     #         docname=None,
     #         lineno=None,
@@ -161,6 +164,7 @@ class TestStandards:
     #     need_1 = NeedsInfoType(
     #         target_id="Organization-specific rules and processes for functional safety",
     #         id="std_wp__iso26262__wp-2-551",
+    #         type="std_wp",
     #         status="valid",
     #         docname=None,
     #         lineno=None,
@@ -173,7 +177,7 @@ class TestStandards:
     #         status="draft",
     #         complies=[
     #             "std_wp__iso26262__wp-2-777",
-    #             "STD_REQ__iso21434__wp-05-88",
+    #             "std_req__iso21434__wp-05-88",
     #         ],
     #         docname=None,
     #         lineno=None,
@@ -215,7 +219,7 @@ class TestStandards:
     #     need_2 = NeedsInfoType(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
-    #         id="WF__CR_MT_SAFETY_PLAN",
+    #         id="wf__cr_mt_safety_plan",
     #         status="draft",
     #         input=["wp__platform_mgmt", "wp__issue_track_system"],
     #         output=["wp__module_safety_plan", "wp__platform_safety_plan"],
@@ -264,7 +268,7 @@ class TestStandards:
     #     need_2 = NeedsInfoType(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
-    #         id="WF__CR_MT_SAFETY_PLAN",
+    #         id="wf__cr_mt_safety_plan",
     #         status="draft",
     #         input=["wp__platform_mgmt", "wp__issue_track_system"],
     #         output=["wp__platform_safety_plan"],
@@ -316,7 +320,7 @@ class TestStandards:
     #     need_2 = NeedsInfoType(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
-    #         id="WF__CR_MT_SAFETY_PLAN",
+    #         id="wf__cr_mt_safety_plan",
     #         status="draft",
     #         input=["wp__platform_mgmt", "wp__issue_track_system"],
     #         output=["wp__module_safety_plan", "wp__platform_safety_plan"],
@@ -334,18 +338,18 @@ class TestStandards:
     #     need_3 = NeedsInfoType(
     #         target_id="Review/Approve Contribution request",
     #         type="workflow",
-    #         id="WF__RV_AP_ContrRequest",
+    #         id="wf__rv_ap_ContrRequest",
     #         status="valid",
     #         input=["wp__cont_request"],
     #         output=["wp__module_safety_plan", "wp__cont_request"],
     #         contains=[
     #             "std_req__iso26262__rq-8-8411",
-    #             "STD_REQ__isoPAS8926__rq-4431",
-    #             "STD_REQ__isoPAS8926__rq-44321",
-    #             "STD_REQ__isoPAS8926__rq-44322",
-    #             "STD_REQ__isoPAS8926__rq-4433",
-    #             "STD_REQ__isoPAS8926__rq-44341",
-    #             "STD_REQ__isoPAS8926__rq-44342",
+    #             "std_req__isoPAS8926__rq-4431",
+    #             "std_req__isoPAS8926__rq-44321",
+    #             "std_req__isoPAS8926__rq-44322",
+    #             "std_req__isoPAS8926__rq-4433",
+    #             "std_req__isoPAS8926__rq-44341",
+    #             "std_req__isoPAS8926__rq-44342",
     #         ],
     #         docname=None,
     #         lineno=None,
@@ -377,6 +381,7 @@ class TestStandards:
         need_1 = NeedsInfoType(
             target_id="Traceability of safety requirements",
             id="std_req__iso26262__rq-8-6432",
+            type="std_req",
             reqtype="Functional",
             status="valid",
             docname=None,
@@ -386,6 +391,7 @@ class TestStandards:
         need_2 = NeedsInfoType(
             target_id="Traceability",
             id="std_req__iso26262__rq-8-0000",
+            type="std_req",
             reqtype="Functional",
             status="valid",
             docname=None,
@@ -394,8 +400,7 @@ class TestStandards:
 
         need_3 = NeedsInfoType(
             target_id="Requirements attribute satisfies",
-            id="GD_REQ__attribute_satisfies",
-            tags="attribute",
+            id="gd_req__attribute_satisfies",
             security="NO",
             type="gd_req",
             complies=[
@@ -404,7 +409,7 @@ class TestStandards:
             ],
             status="valid",
             satisfies=[
-                "GD__create_maintain_requirements",
+                "gd_req__create_maintain_requirements",
             ],
             docname=None,
             lineno=None,
@@ -434,6 +439,7 @@ class TestStandards:
         need_1 = NeedsInfoType(
             target_id="Organization-specific rules and processes for functional safety",
             id="std_wp__iso26262__wp-2-551",
+            type="std_wp",
             status="valid",
             docname=None,
             lineno=None,
@@ -442,6 +448,7 @@ class TestStandards:
         need_2 = NeedsInfoType(
             target_id="specific rules for processes",
             id="std_wp__iso26262__wp-2-0000",
+            type="std_wp",
             status="valid",
             docname=None,
             lineno=None,
@@ -454,7 +461,7 @@ class TestStandards:
             type="workproduct",
             complies=[
                 "std_wp__iso26262__wp-2-551",
-                "STD_REQ__iso21434_wp-05-01",
+                "std_req__iso21434_wp-05-01",
             ],
             docname=None,
             lineno=None,
@@ -499,7 +506,7 @@ class TestStandards:
         need_2 = NeedsInfoType(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
-            id="WF__CR_MT_SAFETY_PLAN",
+            id="wf__cr_mt_safety_plan",
             status="draft",
             input=["wp__platform_mgmt", "wp__issue_track_system"],
             output=["wp__module_safety_plan", "wp__platform_safety_plan"],
@@ -564,18 +571,18 @@ class TestStandards:
         need_6 = NeedsInfoType(
             target_id="Review/Approve Contribution request",
             type="workflow",
-            id="WF__RV_AP_ContrRequest",
+            id="wf__rv_ap_ContrRequest",
             status="valid",
             input=["wp__cont_request"],
             output=["wp__module_safety", "wp__cont_request"],
             contains=[
                 "std_req__iso26262__rq-8-8411",
-                "STD_REQ__isoPAS8926__rq-4431",
-                "STD_REQ__isoPAS8926__rq-44321",
-                "STD_REQ__isoPAS8926__rq-44322",
-                "STD_REQ__isoPAS8926__rq-4433",
-                "STD_REQ__isoPAS8926__rq-44341",
-                "STD_REQ__isoPAS8926__rq-44342",
+                "std_req__isoPAS8926__rq-4431",
+                "std_req__isoPAS8926__rq-44321",
+                "std_req__isoPAS8926__rq-44322",
+                "std_req__isoPAS8926__rq-4433",
+                "std_req__isoPAS8926__rq-44341",
+                "std_req__isoPAS8926__rq-44342",
             ],
             docname=None,
             lineno=None,
@@ -603,6 +610,7 @@ class TestStandards:
         need_1 = NeedsInfoType(
             target_id="Traceability of safety requirements",
             id="std_req__iso26262__rq-8-6432",
+            type="std_req",
             reqtype="Functional",
             status="valid",
             docname=None,
@@ -611,7 +619,8 @@ class TestStandards:
 
         need_2 = NeedsInfoType(
             target_id="Traceability of requirements",
-            id="R_11111111",
+            id="wp__11111111",
+            type="workproduct",
             reqtype="Functional",
             status="valid",
             docname=None,
@@ -631,6 +640,7 @@ class TestStandards:
         need_1 = NeedsInfoType(
             target_id="Organization-specific rules and processes for functional safety",
             id="std_wp__iso26262__wp-2-551",
+            type="std_wp",
             status="valid",
             docname=None,
             lineno=None,
@@ -638,7 +648,8 @@ class TestStandards:
 
         need_2 = NeedsInfoType(
             target_id="Traceability of requirements",
-            id="R_11111111",
+            id="wp__11111111",
+            type="workproduct",
             reqtype="Functional",
             status="valid",
             docname=None,
@@ -658,7 +669,7 @@ class TestStandards:
 
         need_1 = NeedsInfoType(
             target_id="Requirements attribute satisfies",
-            id="GD_REQ__attribute_satisfies",
+            id="gd_req__attribute_satisfies",
             type="workproduct",
             tags="attribute",
             security="NO",
@@ -668,7 +679,7 @@ class TestStandards:
             ],
             status="valid",
             satisfies=[
-                "GD__create_maintain_requirements",
+                "gd_req__create_maintain_requirements",
             ],
             docname=None,
             lineno=None,
@@ -676,7 +687,7 @@ class TestStandards:
 
         need_2 = NeedsInfoType(
             target_id="Requirements attribute satisfies",
-            id="GD_REQ__attribute_satisfies",
+            id="gd_req__attribute_satisfies",
             type="gd_req",
             tags="attribute",
             security="NO",
@@ -686,7 +697,7 @@ class TestStandards:
             ],
             status="valid",
             satisfies=[
-                "GD__create_maintain_requirements",
+                "gd_req__create_maintain_requirements",
             ],
             docname=None,
             lineno=None,
@@ -705,7 +716,7 @@ class TestStandards:
 
         need_1 = NeedsInfoType(
             target_id="Requirements attribute satisfies_1",
-            id="GD_REQ__attribute_satisfies",
+            id="gd_req__attribute_satisfies",
             type="gd_req",
             tags="attribute",
             security="NO",
@@ -714,7 +725,7 @@ class TestStandards:
                 "std_req__iso26262__rq-8-6422",
             ],
             status="valid",
-            satisfies=["GD__create_maintain_requirements"],
+            satisfies=["gd_req__create_maintain_requirements"],
             docname=None,
             lineno=None,
         )
@@ -730,7 +741,7 @@ class TestStandards:
                 "std_wp__iso26262__rq-8-6777",
             ],
             status="valid",
-            satisfies=["GD__create_maintain_requirements"],
+            satisfies=["gd_req__create_maintain_requirements"],
             docname=None,
             lineno=None,
         )
@@ -763,7 +774,7 @@ class TestStandards:
         need_2 = NeedsInfoType(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
-            id="WF__CR_MT_SAFETY_PLAN",
+            id="wf__cr_mt_safety_plan",
             status="draft",
             input=["wp__platform_mgmt", "wp__issue_track_system"],
             output=["wp__module_safety_plan", "wp__platform_safety_plan"],
@@ -807,7 +818,7 @@ class TestStandards:
         need_2 = NeedsInfoType(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
-            id="WF__CSTD_REQ__MT_SAFETY_PLAN",
+            id="wf__cstd_req__mt_safety_plan",
             status="draft",
             input=["wp__platform_mgmt", "wp__issue_track_system"],
             output=["wp__module_safety_plan", "wp__platform_safety_plan"],

--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -34,6 +34,26 @@ def setup(app: Sphinx) -> dict:
     }
 
 
+def find_dir_paths(app: Sphinx) -> list[str]:
+    """
+    Reading 'requirement_links' config value and returning it as list
+    The 'requirement_links' config value contains all source links found
+    that need to be parsed.
+    Args:
+        app: Sphinx app of the current running application
+
+    Returns:
+        (list[str]):
+                List of filenames as strings captured from the 'requirement_links'
+                configuration value.
+
+        Example:
+            [file-1, file-2]
+    """
+    return [app.config.source_code_linker_file]
+
+
+# req-Id: gd_req__req__attr_impl
 def add_source_link(app: Sphinx, env) -> None:
     """
     'Main' function that facilitates the running of all other functions

--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -34,25 +34,6 @@ def setup(app: Sphinx) -> dict:
     }
 
 
-def find_dir_paths(app: Sphinx) -> list[str]:
-    """
-    Reading 'requirement_links' config value and returning it as list
-    The 'requirement_links' config value contains all source links found
-    that need to be parsed.
-    Args:
-        app: Sphinx app of the current running application
-
-    Returns:
-        (list[str]):
-                List of filenames as strings captured from the 'requirement_links'
-                configuration value.
-
-        Example:
-            [file-1, file-2]
-    """
-    return [app.config.source_code_linker_file]
-
-
 # req-Id: gd_req__req__attr_impl
 def add_source_link(app: Sphinx, env) -> None:
     """


### PR DESCRIPTION
Link existing checks via source code linker and implement missing checks.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

We decided to disable the optional_links check for now and correct the finding related to that in a separate PR 

closes #521 