### PR TITLE
ide: Ignore CLion IDE Aspect directory

### DIFF
--- a/.clwb/.idea/.gitignore
+++ b/.clwb/.idea/.gitignore
@@ -9,6 +9,7 @@
 
 # Extended
 /.name
+/aspect
 /editor.xml
 /misc.xml
 /modules.xml


### PR DESCRIPTION
This directory is created by the bazel plugin, and should not persist over different users.