### PR TITLE
docs: refactor collect_source_files.bzl

### DIFF
--- a/docs/_tooling/extensions/score_source_code_linker/collect_source_files.bzl
+++ b/docs/_tooling/extensions/score_source_code_linker/collect_source_files.bzl
@@ -10,75 +10,148 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-CollectedFilesInfo = provider(
+"""
+Bazel rules and aspects for linking source code to documentation.
+
+This module provides:
+- `SourceCodeLinksInfo`: A provider encapsulating parsed source code links. (public)
+- `parse_source_files_for_needs_links`: A function to set up the parsing rule. (public)
+
+Internal implementations:
+- `_collect_source_files_aspect`: An aspect to aggregate source files across dependencies.
+- `_collect_and_parse_source_files`: A rule to collect and parse source files.
+"""
+
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+
+# -----------------------------------------------------------------------------
+# Providers
+# -----------------------------------------------------------------------------
+
+SourceCodeLinksInfo = provider(
+    doc = "Provider containing a JSON file with source code links.",
     fields = {
-        "files": "depset of source files",
+        "file": "Path to JSON file containing source code links.",
     },
 )
 
-def _extract_source_files(rule, attr):
-    collected_source_files = []
-    if hasattr(rule.attr, attr):
-        for src in getattr(rule.attr, attr):
-            for f in src.files.to_list():
-                if not f.path.startswith("external"):
-                    collected_source_files.append(f)
-    return collected_source_files
+# -----------------------------------------------------------------------------
+# Aspect to Collect Source Files (Internal)
+# -----------------------------------------------------------------------------
 
-def _collected_source_files_aspect_impl(target, ctx):
-    collected_source_files = []
-    collected_source_files += _extract_source_files(ctx.rule, "srcs")
-    collected_source_files += _extract_source_files(ctx.rule, "hdrs")
-    collected_source_files_deps = [dep[CollectedFilesInfo].files for dep in ctx.rule.attr.deps]
-    return [CollectedFilesInfo(files = depset(collected_source_files, transitive = collected_source_files_deps))]
+def _extract_source_files(ctx, attr_name):
+    """Extracts source files from a given attribute if it exists."""
+    return [
+        f
+        for src in getattr(ctx.rule.attr, attr_name, [])
+        for f in src.files.to_list()
+        if not f.path.startswith("external")
+    ]
 
-collected_source_files_aspect = aspect(
-    implementation = _collected_source_files_aspect_impl,
+def _collect_source_files_aspect_impl(target, ctx):
+    """Aspect implementation to collect source files from rules and dependencies."""
+    source_files = _extract_source_files(ctx, "srcs") + _extract_source_files(ctx, "hdrs")
+    transitive_files = [
+        dep[SourceCodeLinksInfo].file
+        for dep in getattr(ctx.rule.attr, "deps", [])
+        if SourceCodeLinksInfo in dep
+    ]
+    return [
+        SourceCodeLinksInfo(
+            file = depset(source_files, transitive = transitive_files),
+        ),
+    ]
+
+_collect_source_files_aspect = aspect(
+    implementation = _collect_source_files_aspect_impl,
     attr_aspects = ["deps"],
+    doc = "Aspect that collects source files from a rule and its dependencies. (Internal)",
 )
 
-def _requirement_links_impl(ctx):
-    sources_filename = ctx.label.name
-    sources = ctx.actions.declare_file("%s_sources.txt" % sources_filename)
+# -----------------------------------------------------------------------------
+# Rule to Collect and Parse Source Files (Internal)
+# -----------------------------------------------------------------------------
 
-    accumulated = []
-    for dep in ctx.attr.deps:
-        accumulated.append(dep[CollectedFilesInfo].files)
+def _collect_and_parse_source_files_impl(ctx):
+    """Implementation of a rule that collects and parses source files."""
+    sources_file = ctx.actions.declare_file("%s_sources.txt" % ctx.label.name)
 
-    all_files = depset(transitive = accumulated).to_list()
+    all_files = depset(
+        transitive = [dep[SourceCodeLinksInfo].file for dep in getattr(ctx.attr, "deps", []) if SourceCodeLinksInfo in dep],
+    ).to_list()
 
-    content = ""
-    for filename in all_files:
-        content += "%s\n" % filename.path
-
-    ctx.actions.write(sources, content)
-
-    out_filename = ctx.label.name
-    out = ctx.actions.declare_file("%s.txt" % out_filename)
+    ctx.actions.write(sources_file, "\n".join([f.path for f in all_files]))
+    parsed_sources_json_file = ctx.actions.declare_file("%s.json" % ctx.label.name)
 
     args = ctx.actions.args()
-    args.add(sources)
-    args.add("--output", out)
+    args.add(sources_file)
+    args.add("--output", parsed_sources_json_file)
 
     ctx.actions.run(
         arguments = [args],
-        executable = ctx.executable._tool,
-        inputs = [sources] + all_files,
-        outputs = [out],
+        executable = ctx.executable.source_files_parser,
+        inputs = [sources_file] + all_files,
+        outputs = [parsed_sources_json_file],
     )
 
-    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles([out]))]
+    return [
+        DefaultInfo(
+            files = depset([parsed_sources_json_file]),
+            runfiles = ctx.runfiles([parsed_sources_json_file]),
+        ),
+        SourceCodeLinksInfo(
+            file = parsed_sources_json_file,
+        ),
+    ]
 
-collect_source_files_for_score_source_code_linker = rule(
-    implementation = _requirement_links_impl,
+_collect_and_parse_source_files = rule(
+    implementation = _collect_and_parse_source_files_impl,
     attrs = {
         "deps": attr.label_list(
-            aspects = [collected_source_files_aspect],
+            aspects = [_collect_source_files_aspect],
+            allow_files = True,
+            doc = "Dependencies and files to scan for links to documentation elements.",
         ),
-        "_tool": attr.label(
-            default = "//docs:parsed_source_files_for_source_code_linker",
+        "source_files_parser": attr.label(
             executable = True,
             cfg = "exec",
         ),
     },
+    doc = "Rule that collects and parses source files for linking documentation. (Internal)",
 )
+
+# -----------------------------------------------------------------------------
+# Entry Point for Parsing Source Files (Public)
+# -----------------------------------------------------------------------------
+
+def parse_source_files_for_needs_links(
+        srcs,
+        name = "collected_files_for_score_source_code_linker"):
+    """Sets up parsing of source files for linking to documentation.
+
+    args:
+        srcs: List of source files and dependencies (labels) to parse.
+        name: Name of the rule to create."""
+
+    py_binary(
+        name = "_source_files_parser",
+        srcs = ["//docs:_tooling/extensions/score_source_code_linker/parse_source_files.py"],
+    )
+
+    _collect_and_parse_source_files(
+        name = name,
+        # TODO: shall we call this `srcs` or `deps`?
+        # As it accepts both!
+        deps = srcs,
+        source_files_parser = Label(":_source_files_parser"),
+    )
+
+    return Label("@//" + native.package_name() + ":" + name)
+
+# -----------------------------------------------------------------------------
+# Backwards compatibility
+# -----------------------------------------------------------------------------
+# This should be removed once all references have been updated.
+def collect_source_files_for_score_source_code_linker(deps, name):
+    print("DEPRECATED: Use `parse_source_files_for_needs_links` instead.")
+    parse_source_files_for_needs_links(srcs = deps, name = name)

--- a/docs/_tooling/extensions/score_source_code_linker/collect_source_files.bzl
+++ b/docs/_tooling/extensions/score_source_code_linker/collect_source_files.bzl
@@ -14,18 +14,69 @@
 Bazel rules and aspects for linking source code to documentation.
 
 This module provides:
-- `SourceCodeLinksInfo`: A provider encapsulating parsed source code links. (public)
-- `parse_source_files_for_needs_links`: A function to set up the parsing rule. (public)
-
-Internal implementations:
-- `_collect_source_files_aspect`: An aspect to aggregate source files across dependencies.
-- `_collect_and_parse_source_files`: A rule to collect and parse source files.
+- `SourceCodeLinksInfo`: A provider encapsulating parsed source code links.
+- `parse_source_files_for_needs_links`: A function to set up the parsing rule.
 """
 
-load("@aspect_rules_py//py:defs.bzl", "py_binary")
+# -----------------------------------------------------------------------------
+# Aspect to Collect Source Files (Internal)
+# -----------------------------------------------------------------------------
+
+_CollectedFilesInfo = provider(
+    doc = "Internal provider for collecting all source files.",
+    fields = {
+        "files": "depset of source files",
+    },
+)
+
+def _extract_files_from_attr(ctx, attr_name):
+    """Extracts source files from a given attribute if it exists."""
+    return [
+        f
+        for src in getattr(ctx.rule.attr, attr_name, [])
+        for f in src.files.to_list()
+        if not f.path.startswith("external")
+    ]
+
+def _extract_source_files(ctx):
+    # type: (ctx) -> list[File]
+    """Extracts source files from the context's attributes."""
+    srcs = _extract_files_from_attr(ctx, "srcs")
+    hdrs = _extract_files_from_attr(ctx, "hdrs")
+
+    return srcs + hdrs
+
+def _get_transitive_deps(attr, attr_name):
+    # type: (struct) -> list[Depset]
+    """Extracts previously collected transitive dependencies."""
+    return [
+        dep[_CollectedFilesInfo].files
+        for dep in getattr(attr, attr_name, [])
+        if _CollectedFilesInfo in dep
+    ]
+
+def _collect_source_files_aspect_impl(_target, ctx):
+    """Aspect implementation to collect source files from rules and dependencies."""
+
+    return [
+        _CollectedFilesInfo(
+            files = depset(
+                _extract_source_files(ctx),
+                # Follow deps to collect source files from dependencies.
+                transitive = _get_transitive_deps(ctx.rule.attr, "deps"),
+            ),
+        ),
+    ]
+
+_collect_source_files_aspect = aspect(
+    implementation = _collect_source_files_aspect_impl,
+    # Follow deps to collect source files from dependencies.
+    attr_aspects = ["deps"],
+    doc = "Aspect that collects source files from a rule and its dependencies. (Internal)",
+)
 
 # -----------------------------------------------------------------------------
-# Providers
+# Rule to Collect and Parse Source Files
 # -----------------------------------------------------------------------------
 
 SourceCodeLinksInfo = provider(
@@ -35,49 +86,14 @@ SourceCodeLinksInfo = provider(
     },
 )
 
-# -----------------------------------------------------------------------------
-# Aspect to Collect Source Files (Internal)
-# -----------------------------------------------------------------------------
-
-def _extract_source_files(ctx, attr_name):
-    """Extracts source files from a given attribute if it exists."""
-    return [
-        f
-        for src in getattr(ctx.rule.attr, attr_name, [])
-        for f in src.files.to_list()
-        if not f.path.startswith("external")
-    ]
-
-def _collect_source_files_aspect_impl(target, ctx):
-    """Aspect implementation to collect source files from rules and dependencies."""
-    source_files = _extract_source_files(ctx, "srcs") + _extract_source_files(ctx, "hdrs")
-    transitive_files = [
-        dep[SourceCodeLinksInfo].file
-        for dep in getattr(ctx.rule.attr, "deps", [])
-        if SourceCodeLinksInfo in dep
-    ]
-    return [
-        SourceCodeLinksInfo(
-            file = depset(source_files, transitive = transitive_files),
-        ),
-    ]
-
-_collect_source_files_aspect = aspect(
-    implementation = _collect_source_files_aspect_impl,
-    attr_aspects = ["deps"],
-    doc = "Aspect that collects source files from a rule and its dependencies. (Internal)",
-)
-
-# -----------------------------------------------------------------------------
-# Rule to Collect and Parse Source Files (Internal)
-# -----------------------------------------------------------------------------
-
 def _collect_and_parse_source_files_impl(ctx):
     """Implementation of a rule that collects and parses source files."""
     sources_file = ctx.actions.declare_file("%s_sources.txt" % ctx.label.name)
 
     all_files = depset(
-        transitive = [dep[SourceCodeLinksInfo].file for dep in getattr(ctx.attr, "deps", []) if SourceCodeLinksInfo in dep],
+        # Collect source files from the current rule.
+        # The rule has an "srcs" attribute.
+        transitive = _get_transitive_deps(ctx.attr, "srcs_and_deps"),
     ).to_list()
 
     ctx.actions.write(sources_file, "\n".join([f.path for f in all_files]))
@@ -89,7 +105,7 @@ def _collect_and_parse_source_files_impl(ctx):
 
     ctx.actions.run(
         arguments = [args],
-        executable = ctx.executable.source_files_parser,
+        executable = ctx.executable._source_files_parser,
         inputs = [sources_file] + all_files,
         outputs = [parsed_sources_json_file],
     )
@@ -104,49 +120,27 @@ def _collect_and_parse_source_files_impl(ctx):
         ),
     ]
 
-_collect_and_parse_source_files = rule(
+parse_source_files_for_needs_links = rule(
     implementation = _collect_and_parse_source_files_impl,
     attrs = {
-        "deps": attr.label_list(
+        "srcs_and_deps": attr.label_list(
             aspects = [_collect_source_files_aspect],
             allow_files = True,
             doc = "Dependencies and files to scan for links to documentation elements.",
         ),
-        "source_files_parser": attr.label(
+        "_source_files_parser": attr.label(
+            # TODO: rename to source_files_parser in next PR
+            default = Label("//docs:parsed_source_files_for_source_code_linker"),
             executable = True,
             cfg = "exec",
         ),
     },
+    provides = [
+        DefaultInfo,
+        SourceCodeLinksInfo,
+    ],
     doc = "Rule that collects and parses source files for linking documentation. (Internal)",
 )
-
-# -----------------------------------------------------------------------------
-# Entry Point for Parsing Source Files (Public)
-# -----------------------------------------------------------------------------
-
-def parse_source_files_for_needs_links(
-        srcs,
-        name = "collected_files_for_score_source_code_linker"):
-    """Sets up parsing of source files for linking to documentation.
-
-    args:
-        srcs: List of source files and dependencies (labels) to parse.
-        name: Name of the rule to create."""
-
-    py_binary(
-        name = "_source_files_parser",
-        srcs = ["//docs:_tooling/extensions/score_source_code_linker/parse_source_files.py"],
-    )
-
-    _collect_and_parse_source_files(
-        name = name,
-        # TODO: shall we call this `srcs` or `deps`?
-        # As it accepts both!
-        deps = srcs,
-        source_files_parser = Label(":_source_files_parser"),
-    )
-
-    return Label("@//" + native.package_name() + ":" + name)
 
 # -----------------------------------------------------------------------------
 # Backwards compatibility
@@ -154,4 +148,4 @@ def parse_source_files_for_needs_links(
 # This should be removed once all references have been updated.
 def collect_source_files_for_score_source_code_linker(deps, name):
     print("DEPRECATED: Use `parse_source_files_for_needs_links` instead.")
-    parse_source_files_for_needs_links(srcs = deps, name = name)
+    parse_source_files_for_needs_links(srcs_and_deps = deps, name = name)


### PR DESCRIPTION
New feature: it can now also handle filegroups as an input, as it no longer assumes every rule has a "deps" attribute.
Otherwise it's only refactoring.