### PR TITLE
docs: Fix warnings via esbonio

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -64,7 +64,7 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
 
     logger.debug(f"Running checks for {len(needs_all_needs)} needs")
 
-    log = CheckLogger(logger)
+    log = CheckLogger(logger, app)
 
     # Need-Local checks: checks which can be checked file-local, without a
     # graph of other needs.

--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -64,7 +64,9 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
 
     logger.debug(f"Running checks for {len(needs_all_needs)} needs")
 
-    log = CheckLogger(logger, app)
+    prefix = Path(app.srcdir).relative_to(Path.cwd())
+
+    log = CheckLogger(logger, prefix)
 
     # Need-Local checks: checks which can be checked file-local, without a
     # graph of other needs.

--- a/docs/_tooling/extensions/score_metamodel/log.py
+++ b/docs/_tooling/extensions/score_metamodel/log.py
@@ -10,34 +10,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+import os
+from pathlib import Path
+
+from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.logging import SphinxLoggerAdapter
 
 
 class CheckLogger:
-    def __init__(self, log: SphinxLoggerAdapter):
+    def __init__(self, log: SphinxLoggerAdapter, app: Sphinx):
         self._log = log
         self._count = 0
+        self._app = app
 
     @staticmethod
-    def _location(need: NeedsInfoType):
+    def _location(need: NeedsInfoType, app: Sphinx):
         def get(key):
             return need.get(key, None)
 
         if get("docname") and get("doctype") and get("lineno"):
             # Note: passing the location as a string allows us to use readable relative paths,
             # passing as a tuple results in absolute paths to ~/.cache/.../bazel-out/..
-            return f"{need['docname']}{need['doctype']}:{need['lineno']}"
+            if "RUNFILES_DIR" in os.environ or "RUNFILES_MANIFEST_FILE" in os.environ:
+                matching_file = f"{need['docname']}{need['doctype']}"
+            else:
+                prefix = Path(app.srcdir).relative_to(Path.cwd())
+                matching_file = f"{prefix}/{need['docname']}{need['doctype']}"
+
+            return f"{matching_file}:{need['lineno']}"
         return None
 
     def warning_for_option(self, need: NeedsInfoType, option: str, msg: str):
         self.warning(
             f"{need['id']}.{option} ({need.get(option, None)}): " + msg,
-            location=CheckLogger._location(need),
+            location=CheckLogger._location(need, self._app),
         )
 
     def warning_for_need(self, need: NeedsInfoType, msg: str):
-        self.warning(f"{need['id']}: " + msg, location=CheckLogger._location(need))
+        self.warning(
+            f"{need['id']}: " + msg, location=CheckLogger._location(need, self._app)
+        )
 
     def warning(self, msg: str, location=None):
         self._log.warning(msg, type="score_metamodel", location=location)

--- a/docs/_tooling/extensions/score_metamodel/log.py
+++ b/docs/_tooling/extensions/score_metamodel/log.py
@@ -11,21 +11,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 import os
-from pathlib import Path
 
-from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
 from sphinx_needs.logging import SphinxLoggerAdapter
 
 
 class CheckLogger:
-    def __init__(self, log: SphinxLoggerAdapter, app: Sphinx):
+    def __init__(self, log: SphinxLoggerAdapter, prefix: str):
         self._log = log
         self._count = 0
-        self._app = app
+        self._prefix = prefix
 
     @staticmethod
-    def _location(need: NeedsInfoType, app: Sphinx):
+    def _location(need: NeedsInfoType, prefix: str):
         def get(key):
             return need.get(key, None)
 
@@ -35,7 +33,6 @@ class CheckLogger:
             if "RUNFILES_DIR" in os.environ or "RUNFILES_MANIFEST_FILE" in os.environ:
                 matching_file = f"{need['docname']}{need['doctype']}"
             else:
-                prefix = Path(app.srcdir).relative_to(Path.cwd())
                 matching_file = f"{prefix}/{need['docname']}{need['doctype']}"
 
             return f"{matching_file}:{need['lineno']}"
@@ -44,12 +41,12 @@ class CheckLogger:
     def warning_for_option(self, need: NeedsInfoType, option: str, msg: str):
         self.warning(
             f"{need['id']}.{option} ({need.get(option, None)}): " + msg,
-            location=CheckLogger._location(need, self._app),
+            location=CheckLogger._location(need, self._prefix),
         )
 
     def warning_for_need(self, need: NeedsInfoType, msg: str):
         self.warning(
-            f"{need['id']}: " + msg, location=CheckLogger._location(need, self._app)
+            f"{need['id']}: " + msg, location=CheckLogger._location(need, self._prefix)
         )
 
     def warning(self, msg: str, location=None):

--- a/docs/_tooling/extensions/score_metamodel/tests/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/__init__.py
@@ -27,8 +27,8 @@ def fake_check_logger():
         def __init__(self):
             self._mock_logger = MagicMock(spec=SphinxLoggerAdapter)
             self._mock_logger.warning = MagicMock()
-            app = MagicMock(spec=Sphinx)
-            super().__init__(self._mock_logger, app)
+            app_path = MagicMock()
+            super().__init__(self._mock_logger, app_path)
 
         def assert_no_warnings(self):
             if self.has_warnings:

--- a/docs/_tooling/extensions/score_metamodel/tests/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/__init__.py
@@ -13,6 +13,8 @@
 from unittest.mock import MagicMock
 
 import pytest
+
+from sphinx.application import Sphinx
 from sphinx.util.logging import SphinxLoggerAdapter
 
 from docs._tooling.extensions.score_metamodel import CheckLogger, NeedsInfoType
@@ -25,7 +27,8 @@ def fake_check_logger():
         def __init__(self):
             self._mock_logger = MagicMock(spec=SphinxLoggerAdapter)
             self._mock_logger.warning = MagicMock()
-            super().__init__(self._mock_logger)
+            app = MagicMock(spec=Sphinx)
+            super().__init__(self._mock_logger, app)
 
         def assert_no_warnings(self):
             if self.has_warnings:


### PR DESCRIPTION
# Bugfix


## Description

Esbonio warnings have correct file path while keeping a correct file path for bazel build and run.

## Related ticket

closes [#174] (bugfix ticket)