### PR TITLE
docs: Disabling 'traceability-checks.

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/checks/traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/traceability.py
@@ -10,90 +10,91 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType
 
-from score_metamodel import CheckLogger, graph_check
-
-
-@graph_check
-def check_linkage_parent(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
-    """
-    Checking if all linked parent requirements have status valid.
-    """
-    # Convert list to dictionary for easy lookup
-    needs_dict = {need["id"]: need for need in needs}
-
-    for need in needs:
-        parents_not_correct = []
-        for satisfie_need in need.get("satisfies", []):
-            if needs_dict.get(satisfie_need, {}).get("status") != "valid":
-                parents_not_correct.append(satisfie_need)
-
-        if parents_not_correct:
-            formatted_parents_not_correct = ", ".join(
-                f"`{parent}`" for parent in parents_not_correct
-            )
-            msg = f"has a parent requirement(s): {formatted_parents_not_correct} with an invalid status."
-            log.warning_for_need(need, msg)
+#          ╭──────────────────────────────────────╮
+#          │      CHECKS DISABLED ON PURPOSE      │
+#          ╰──────────────────────────────────────╯
 
 
-@graph_check
-def check_linkage_safety(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
-    """
-    Checking if for feature, component and tool requirements it shall be checked if at least one parent requirement
-    contains the same or lower ASIL compared to the ASIL of the current requirement then it will return False.
-    """
-    # Convert list to dictionary for easy lookup
-    needs_dict = {need["id"]: need for need in needs}
-
-    for need in needs:
-        allowed_values = ["QM"]
-        parents_have_safety = False
-
-        if need["safety"] == "QM":
-            return
-        elif need["safety"] == "ASIL_B":
-            for satisfie_need in need.get("satisfies", []):
-                safety = needs_dict.get(satisfie_need, {}).get(
-                    "safety"
-                )  # Lookup parent need safely
-                allowed_values = ["ASIL_B", "ASIL_D"]
-                if safety:
-                    parents_have_safety = True
-                if safety in ["ASIL_B", "ASIL_D"]:
-                    continue
-        elif need["safety"] == "ASIL_D":
-            for satisfie_need in need.get("satisfies", []):
-                safety = needs_dict.get(satisfie_need, {}).get(
-                    "safety"
-                )  # Lookup parent need safely
-                if safety:
-                    parents_have_safety = True
-                allowed_values = ["ASIL_D"]
-                if safety == "ASIL_D":
-                    continue
-
-        # Checking if the requirement has satisfies field before logging
-        if need.get("satisfies") and parents_have_safety:
-            msg = (
-                f"with `{need['safety']}` has no parent requirement that contains the same or lower ASIL. "
-                f"Allowed ASIL values: {', '.join(f'`{value}`' for value in allowed_values)}. \n"
-            )
-            log.warning_for_need(need, msg)
-
-
-@graph_check
-def check_linkage_status(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
-    """
-    Checking if for valid feature, component and tool requirements it shall be checked if the status of the parent requirement is also valid.
-    """
-    needs_dict = {need["id"]: need for need in needs}
-    for need in needs:
-        if need["status"] == "valid":
-            for satisfie_need in need.get("satisfies", []):
-                parent_need = needs_dict.get(satisfie_need)  # Get parent requirement
-
-                if not parent_need or parent_need.get("status") != "valid":
-                    msg = f"has a valid status but one of its parents: `{satisfie_need}` has an invalid status. \n"
-                    log.warning_for_need(need, msg)
+# from sphinx.application import Sphinx
+# from sphinx_needs.data import NeedsInfoType
+#
+# from score_metamodel import CheckLogger, graph_check
+#
+#
+# @graph_check
+# def check_linkage_parent(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
+#     """
+#     Checking if all linked parent requirements have status valid.
+#     """
+#     # Convert list to dictionary for easy lookup
+#     needs_dict = {need["id"]: need for need in needs}
+#
+#     for need in needs:
+#         parents_not_correct = []
+#         for satisfie_need in need.get("satisfies", []):
+#             if needs_dict.get(satisfie_need, {}).get("status") != "valid":
+#                 parents_not_correct.append(satisfie_need)
+#
+#         if parents_not_correct:
+#             formatted_parents_not_correct = ", ".join(
+#                 f"`{parent}`" for parent in parents_not_correct
+#             )
+#             msg = f"has a parent requirement(s): {formatted_parents_not_correct} with an invalid status."
+#             log.warning_for_need(need, msg)
+#
+#
+# @graph_check
+# def check_linkage_safety(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
+#     """
+#     Checking if for feature, component and tool requirements it shall be checked if at least one parent requirement
+#     contains the same or lower ASIL compared to the ASIL of the current requirement then it will return False.
+#     """
+#     # Convert list to dictionary for easy lookup
+#     needs_dict = {need["id"]: need for need in needs}
+#
+#     # Mapping of 'Need safety: Allowed parent safety'
+#     allowed_values_map = {"ASIL_B":
+#                                     ["ASIL_B", "ASIL_D"],
+#                           "ASIL_D":
+#                                     ["ASIL_D"]
+#                           }
+#
+#     for need in needs:
+#         # We can skip anything that has no satisfies or is safety level 'QM'
+#         if not need["satisfies"] or not need["safety"]:
+#             continue
+#
+#         if need["safety"] == "QM":
+#            continue
+#
+#
+#         allowed_values = allowed_values_map.get(need["safety"], [])
+#         unsafe_parents = []
+#         for satisfie_need in  need.get("satisfies", []):
+#             parent = needs_dict.get(satisfie_need, {})
+#             parent_safety = parent.get("safety", "")
+#             if not parent_safety or parent_safety not in allowed_values:
+#                 unsafe_parents.append(parent)
+#         if unsafe_parents:
+#             msg = (
+#                 f"`{need['id']}` parents: {unsafe_parents} have either no, or not allowed safety ASIL values. "
+#                 f"Allowed ASIL values: {', '.join(f'`{value}`' for value in allowed_values)}. \n"
+#             )
+#             log.warning_for_need(need, msg)
+#
+#
+# @graph_check
+# def check_linkage_status(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
+#     """
+#     Checking if for valid feature, component and tool requirements it shall be checked if the status of the parent requirement is also valid.
+#     """
+#     needs_dict = {need["id"]: need for need in needs}
+#     for need in needs:
+#         if need["status"] == "valid":
+#             for satisfie_need in need.get("satisfies", []):
+#                 parent_need = needs_dict.get(satisfie_need)  # Get parent requirement
+#
+#                 if not parent_need or parent_need.get("status") != "valid":
+#                     msg = f"has a valid status but one of its parents: `{satisfie_need}` has an invalid status. \n"
+#                     log.warning_for_need(need, msg)

--- a/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
@@ -10,208 +10,216 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-from unittest.mock import Mock
-
-import pytest
-from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType
-
-import score_metamodel.tests as tests
-from score_metamodel.checks.traceability import (
-    check_linkage_parent,
-    check_linkage_safety,
-    check_linkage_status,
-)
 
 
-@pytest.mark.metadata(
-    Verifies=[
-        "TOOL_REQ__toolchain_sphinx_needs_build__requirement_linkage_status_check"
-    ],
-    Description="It should check the traceability like linkage of attributes.",
-    ASIL="ASIL_D",
-    Priority="1",
-    TestType="Requirements-based test",
-    DerivationTechnique="Analysis of requirements",
-)
-class TestTraceability:
-    def test_check_linkage_parent_positive(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
+#          ╭──────────────────────────────────────╮
+#          │  TEST DISABLED DUE TO CHECKS BEING   │
+#          │               DISABLED               │
+#          ╰──────────────────────────────────────╯
 
-        need_1 = NeedsInfoType(
-            id="TOOL_REQ__1",
-            status="valid",
-            satisfies=[
-                "feat_req__2",
-            ],
-        )
 
-        need_2 = NeedsInfoType(
-            id="feat_req__2",
-            status="valid",
-            satisfies=[
-                "TOOL_REQ__1",
-            ],
-        )
-        needs = [need_1, need_2]
-
-        check_linkage_parent(app, needs, logger)
-        logger.assert_no_warnings()
-
-    def test_check_linkage_parent_negative(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="TOOL_REQ__1",
-            status="valid",
-            satisfies=[
-                "feat_req__2",
-            ],
-        )
-
-        needs = [need_1]
-
-        check_linkage_parent(app, needs, logger)
-
-        logger.assert_warning(
-            f"has a parent requirement(s): `{need_1['satisfies'][0]}` with an invalid status.",
-            expect_location=False,
-        )
-
-    def test_check_linkage_safety_positive(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="COMP_REQ__1",
-            status="valid",
-            safety="QM",
-            satisfies=[
-                "feat_req__2",
-            ],
-        )
-
-        need_2 = NeedsInfoType(
-            id="feat_req__2",
-            status="valid",
-            safety="QM",
-            satisfies=[
-                "stkh_req__communication__intra_process",
-            ],
-        )
-
-        need_3 = NeedsInfoType(
-            id="stkh_req__communication__intra_process",
-            status="valid",
-            safety="QM",
-        )
-
-        needs = [need_1, need_2, need_3]
-
-        check_linkage_safety(app, needs, logger)
-        logger.assert_no_warnings()
-
-    def test_check_linkage_safety_negative_ASIL_D(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="feat_req__1",
-            safety="ASIL_D",
-            satisfies=[
-                "stkh_req__communication__inter_process",
-            ],
-        )
-
-        need_2 = NeedsInfoType(
-            id="stkh_req__communication__inter_process",
-            status="valid",
-            safety="ASIL_B",
-        )
-
-        needs = [need_1, need_2]
-
-        check_linkage_safety(app, needs, logger)
-        logger.assert_warning(
-            f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_D`.",
-            expect_location=False,
-        )
-
-    def test_check_linkage_safety_negative_ASIL_B(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="feat_req__1",
-            safety="ASIL_B",
-            satisfies=[
-                "stkh_req__communication__inter_process",
-            ],
-        )
-
-        need_2 = NeedsInfoType(
-            id="stkh_req__communication__inter_process",
-            safety="QM",
-        )
-        needs = [need_1, need_2]
-
-        check_linkage_safety(app, needs, logger)
-        logger.assert_warning(
-            f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_B`, `ASIL_D`.",
-            expect_location=False,
-        )
-
-    def test_check_linkage_status_positive(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="TOOL_REQ__1",
-            status="valid",
-            satisfies=[
-                "feat_req__2",
-            ],
-        )
-
-        need_2 = NeedsInfoType(
-            id="feat_req__2",
-            status="valid",
-        )
-        needs = [need_1, need_2]
-
-        check_linkage_status(app, needs, logger)
-        logger.assert_no_warnings()
-
-    def test_check_linkage_status_negative(self):
-        logger = tests.fake_check_logger()
-        app = Mock(spec=Sphinx)
-
-        need_1 = NeedsInfoType(
-            id="TOOL_REQ__001",
-            status="valid",
-            satisfies=["feat_req__2"],
-        )
-
-        need_2 = NeedsInfoType(
-            id="feat_req__2",
-            status="valid",
-            satisfies=[
-                "feat_req__3",
-            ],
-        )
-        need_3 = NeedsInfoType(
-            id="feat_req__3",
-            status="invalid",
-            satisfies=[
-                "feat_req__4",
-            ],
-        )
-        needs = [need_1, need_2, need_3]
-        check_linkage_status(app, needs, logger)
-
-        logger.assert_warning(
-            "has a valid status but one of its parents: `feat_req__3` has an invalid status.",
-            expect_location=False,
-        )
+# from unittest.mock import Mock
+#
+# import pytest
+# from sphinx.application import Sphinx
+# from sphinx_needs.data import NeedsInfoType
+#
+# import score_metamodel.tests as tests
+# from score_metamodel.checks.traceability import (
+#     check_linkage_parent,
+#     check_linkage_safety,
+#     check_linkage_status,
+# )
+#
+#
+# @pytest.mark.metadata(
+#     Verifies=[
+#         "TOOL_REQ__toolchain_sphinx_needs_build__requirement_linkage_status_check"
+#     ],
+#     Description="It should check the traceability like linkage of attributes.",
+#     ASIL="ASIL_D",
+#     Priority="1",
+#     TestType="Requirements-based test",
+#     DerivationTechnique="Analysis of requirements",
+# )
+# class TestTraceability:
+#     def test_check_linkage_parent_positive(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="TOOL_REQ__1",
+#             status="valid",
+#             satisfies=[
+#                 "feat_req__2",
+#             ],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="feat_req__2",
+#             status="valid",
+#             satisfies=[
+#                 "TOOL_REQ__1",
+#             ],
+#         )
+#         needs = [need_1, need_2]
+#
+#         check_linkage_parent(app, needs, logger)
+#         logger.assert_no_warnings()
+#
+#     def test_check_linkage_parent_negative(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="TOOL_REQ__1",
+#             status="valid",
+#             satisfies=[
+#                 "feat_req__2",
+#             ],
+#         )
+#
+#         needs = [need_1]
+#
+#         check_linkage_parent(app, needs, logger)
+#
+#         logger.assert_warning(
+#             f"has a parent requirement(s): `{need_1['satisfies'][0]}` with an invalid status.",
+#             expect_location=False,
+#         )
+#
+#     def test_check_linkage_safety_positive(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="COMP_REQ__1",
+#             status="valid",
+#             safety="QM",
+#             satisfies=[
+#                 "feat_req__2",
+#             ],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="feat_req__2",
+#             status="valid",
+#             safety="QM",
+#             satisfies=[
+#                 "stkh_req__communication__intra_process",
+#             ],
+#         )
+#
+#         need_3 = NeedsInfoType(
+#             id="stkh_req__communication__intra_process",
+#             status="valid",
+#             safety="QM",
+#         )
+#
+#         needs = [need_1, need_2, need_3]
+#
+#         check_linkage_safety(app, needs, logger)
+#         logger.assert_no_warnings()
+#
+#     def test_check_linkage_safety_negative_ASIL_D(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="feat_req__1",
+#             safety="ASIL_D",
+#             satisfies=[
+#                 "stkh_req__communication__inter_process",
+#             ],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="stkh_req__communication__inter_process",
+#             status="valid",
+#             safety="ASIL_B",
+#         )
+#
+#         needs = [need_1, need_2]
+#
+#         check_linkage_safety(app, needs, logger)
+#         logger.assert_warning(
+#             f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_D`.",
+#             expect_location=False,
+#         )
+#
+#     def test_check_linkage_safety_negative_ASIL_B(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="feat_req__1",
+#             safety="ASIL_B",
+#             satisfies=[
+#                 "stkh_req__communication__inter_process",
+#             ],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="stkh_req__communication__inter_process",
+#             safety="QM",
+#         )
+#         needs = [need_1, need_2]
+#
+#         check_linkage_safety(app, needs, logger)
+#         logger.assert_warning(
+#             f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_B`, `ASIL_D`.",
+#             expect_location=False,
+#         )
+#
+#     def test_check_linkage_status_positive(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="TOOL_REQ__1",
+#             status="valid",
+#             satisfies=[
+#                 "feat_req__2",
+#             ],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="feat_req__2",
+#             status="valid",
+#         )
+#         needs = [need_1, need_2]
+#
+#         check_linkage_status(app, needs, logger)
+#         logger.assert_no_warnings()
+#
+#     def test_check_linkage_status_negative(self):
+#         logger = tests.fake_check_logger()
+#         app = Mock(spec=Sphinx)
+#
+#         need_1 = NeedsInfoType(
+#             id="TOOL_REQ__001",
+#             status="valid",
+#             satisfies=["feat_req__2"],
+#         )
+#
+#         need_2 = NeedsInfoType(
+#             id="feat_req__2",
+#             status="valid",
+#             satisfies=[
+#                 "feat_req__3",
+#             ],
+#         )
+#         need_3 = NeedsInfoType(
+#             id="feat_req__3",
+#             status="invalid",
+#             satisfies=[
+#                 "feat_req__4",
+#             ],
+#         )
+#         needs = [need_1, need_2, need_3]
+#         check_linkage_status(app, needs, logger)
+#
+#         logger.assert_warning(
+#             "has a valid status but one of its parents: `feat_req__3` has an invalid status.",
+#             expect_location=False,
+#         )


### PR DESCRIPTION
Traceability checks being disabled
The checks will be moved to the metamodel graph checks in a future PR.
