### PR TITLE
tooling: Correct Ruff and Pylance error

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -174,7 +174,8 @@ def load_metamodel_data():
 
     # We have to remove all 'default options' from the extra options.
     # As otherwise sphinx errors, due to an option being registered twice.
-    # They are still inside the extra options we extract to enable constraint checking via regex
+    # They are still inside the extra options we extract to enable
+    # constraint checking via regex
     needs_extra_options = sorted(all_options - set(default_options_list))
 
     return {
@@ -188,7 +189,10 @@ def load_metamodel_data():
 
 
 def default_options() -> list[str]:
-    "Helper function to get a list of all default options defined by sphinx, sphinx-needs etc."
+    """
+    Helper function to get a list of all default options defined by
+    sphinx, sphinx-needs etc.
+    """
     return [
         "target_id",
         "id",

--- a/docs/_tooling/extensions/score_metamodel/checks/attributes_format.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/attributes_format.py
@@ -21,7 +21,8 @@ from score_metamodel import CheckLogger, local_check
 @local_check
 def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     """
-    Checking if the title, directory and feature are included in the requirement id or not.
+    Checking if the title, directory and feature are included in
+    the requirement id or not.
     ---
     """
     # Split the string by underscores
@@ -31,11 +32,18 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
         ("gd_", "wf__", "wp__", "rl__", "stkh_req__", "tool_req__", "doc__")
     ) or ("process/" in need.get("docname", "")):
         if len(parts) != 2 and len(parts) != 3:
-            msg = "expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`."
+            msg = (
+                "expected to consisting of one of these 2 formats:"
+                "`<Req Type>__<Abbreviations>` or "
+                "`<Req Type>__<Abbreviations>__<Architectural Element>`."
+            )
             log.warning_for_option(need, "id", msg)
     else:
         if len(parts) != 3:
-            msg = "expected to consisting of this format: `<Req Type>__<Abbreviations>__<Architectural Element>`."
+            msg = (
+                "expected to consisting of this format: "
+                "`<Req Type>__<Abbreviations>__<Architectural Element>`."
+            )
             log.warning_for_option(need, "id", msg)
 
 
@@ -43,12 +51,16 @@ def check_id_format(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
 def check_id_length(app: Sphinx, need: NeedsInfoType, log: CheckLogger):
     """
     Validates that the requirement ID does not exceed the hard limit of 45 characters.
-    While the recommended limit is 30 characters, this check enforces a strict maximum of 45 characters.
+    While the recommended limit is 30 characters, this check enforces a strict maximum
+    of 45 characters.
     If the ID exceeds 45 characters, a warning is logged specifying the actual length.
     ---
     """
     if len(need["id"]) > 45:
-        msg = f"exceeds the maximum allowed length of 45 characters (current length: {len(need['id'])})."
+        msg = (
+            f"exceeds the maximum allowed length of 45 characters "
+            f"(current length: {len(need['id'])})."
+        )
         log.warning_for_option(need, "id", msg)
 
 

--- a/docs/_tooling/extensions/score_metamodel/checks/check_options.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/check_options.py
@@ -81,7 +81,8 @@ def check_options(
     needs_types: list[NeedsInfoType] = None,
 ):
     """
-    Checks that required and optional options and links are present and follow their defined patterns.
+    Checks that required and optional options and links are present
+    and follow their defined patterns.
     """
     production_needs_types = app.config.needs_types
     if not needs_types:
@@ -127,7 +128,9 @@ def check_extra_options(
     needs_types: list[NeedsInfoType] = None,
 ):
     """
-    This function checks if the user specified attributes in the need which are not defined for this element in the metamodel or by default system attributes.
+    This function checks if the user specified attributes in the need
+    which are not defined for this element in the metamodel or by default
+    system attributes.
     """
 
     production_needs_types = app.config.needs_types

--- a/docs/_tooling/extensions/score_metamodel/checks/graph_checks.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/graph_checks.py
@@ -42,15 +42,15 @@ def eval_need_check(need, check, log):
     if len(parts) != 3:
         raise ValueError(f"Invalid check defined: {check}")
 
-    if not (parts[1] in oper):
+    if parts[1] not in oper:
         raise ValueError(f"Binary Operator not defined: {parts[1]}")
 
-    if parts[0] not in need.keys():
+    if parts[0] not in need:
         msg = f"Attribute not defined: {parts[0]}"
         log.warning_for_need(need, msg)
         return False
-    else:
-        return oper[parts[1]](need[parts[0]], parts[2])
+
+    return oper[parts[1]](need[parts[0]], parts[2])
 
 
 def eval_need_condition(need, condition, log):

--- a/docs/_tooling/extensions/score_metamodel/checks/standards.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/standards.py
@@ -10,13 +10,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-from sphinx.application import Sphinx
+# from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
 
-from score_metamodel import (
-    CheckLogger,
-    graph_check,
-)
+# from score_metamodel import (
+#    CheckLogger,
+#    graph_check,
+# )
 
 
 def get_standards_needs(needs: list[NeedsInfoType]) -> dict:
@@ -79,15 +79,16 @@ def get_compliance_wp_needs(needs) -> set:
     }
 
 
-#                    ╭──────────────────────────────────────────────────────────────────────────────╮
-#                    │                             Disabled temporarly                              │
-#                    ╰──────────────────────────────────────────────────────────────────────────────╯
+#        ╭─────────────────────────────────────────────────────────────────────────────╮
+#        │                             Disabled temporarly                             │
+#        ╰─────────────────────────────────────────────────────────────────────────────╯
 # @graph_check
 # def check_all_standard_req_linked_item_via_the_compliance_req(
 #     app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger
 # ):
 #     """
-#     Checks if all standard requirements are linked to an item via the compliance_req tag.
+#     Checks if all standard requirements are linked to an item via the compliance_req
+#     tag.
 #     Logs a warning for each unlinked standard requirement.
 #     """
 #     standards_needs = get_standards_needs(needs)
@@ -95,7 +96,10 @@ def get_compliance_wp_needs(needs) -> set:
 #
 #     for need in standards_needs.values():
 #         if need["id"] not in compliance_req_needs:
-#             msg = f"Standard requirement `{need['id']}` is not linked to at least one item via the complies tag. \n"
+#             msg = (
+#                   f"Standard requirement `{need['id']}` is not linked to at least "
+#                   f"one item via the complies tag. \n"
+#                   )
 #             log.warning_for_option(need, "id", msg)
 #
 # @graph_check
@@ -112,8 +116,8 @@ def get_compliance_wp_needs(needs) -> set:
 #     for need in standards_workproducts.values():
 #         if need["id"] not in compliance_wp_needs:
 #             msg = (
-#                 f"Standard workproduct `{need['id']}` is not linked to at least one item "
-#                 f"via the complies tag. \n"
+#                 f"Standard workproduct `{need['id']}` is not linked to at least one"
+#                 f" item via the complies tag. \n"
 #             )
 #             log.warning_for_option(need, "id", msg)
 #
@@ -136,9 +140,9 @@ def get_compliance_wp_needs(needs) -> set:
 #     }
 #
 #     # Iterate over workflows and update the counts and workflows
-#     for workflow_id, workflow in all_workflows.items():
+#     for workflow in all_workflows.values():
 #         for output in workflow["output"]:
-#             # If the workproduct is in the analysis, increment its count and add the workflow_id
+#             # Increment count and add workflow_id if workproduct is in analysis
 #             if output in workproduct_analysis:
 #                 workproduct_analysis[output]["count"] += 1
 #                 workproduct_analysis[output]["workflows"].append(workflow_id)
@@ -157,18 +161,22 @@ def get_compliance_wp_needs(needs) -> set:
 #                 workflows_str = ", ".join(
 #                     f"`{workflow}`" for workflow in workflows
 #                 )  # Join workflow IDs into a string
-#                 msg = f"is contained in {count} workflows: {workflows_str}, which is incorrect. \n"
+#                 msg = (
+#                       f"is contained in {count} workflows: {workflows_str},"
+#                       f"which is incorrect. \n"
+#                        )
 #                 log.warning_for_need(workproduct, msg)
 #
 #
-#                    ╭──────────────────────────────────────────────────────────────────────────────╮
-#                    │                            END OF TEMP DISABLING                             │
-#                    ╰──────────────────────────────────────────────────────────────────────────────╯
+#        ╭─────────────────────────────────────────────────────────────────────────────╮
+#        │                            END OF TEMP DISABLING                            │
+#        ╰─────────────────────────────────────────────────────────────────────────────╯
 
 
 def my_pie_linked_standard_requirements(needs, results, **kwargs):
     """
-    Function to render the chart of check for standard requirements linked to at least an item via compliance-gd.
+    Function to render the chart of check for standard requirements linked
+    to at least an item via compliance-gd.
     """
     cnt_connected = 0
     cnt_not_connected = 0
@@ -188,7 +196,8 @@ def my_pie_linked_standard_requirements(needs, results, **kwargs):
 
 def my_pie_linked_standard_workproducts(needs, results, **kwargs):
     """
-    Function to render the chart of check for standar workproducts linked to at least an item via compliance-wp.
+    Function to render the chart of check for standar workproducts linked
+    to at least an item via compliance-wp.
     """
     cwp_connected = 0
     cwp_not_connected = 0
@@ -209,7 +218,9 @@ def my_pie_linked_standard_workproducts(needs, results, **kwargs):
 
 def my_pie_workproducts_contained_in_exactly_one_workflow(needs, results, **kwargs):
     """
-    Function to render the chart of check for workproducts that are contained in exactly one workflow, the not connected once and the once that are connected to multiple workflows.
+    Function to render the chart of check for workproducts that are contained
+    in exactly one workflow, the not connected once and the once
+    that are connected to multiple workflows.
     """
     all_workflows = get_workflows(needs)
     all_workproducts = get_workproducts(needs)
@@ -218,9 +229,9 @@ def my_pie_workproducts_contained_in_exactly_one_workflow(needs, results, **kwar
     workproduct_analysis = {wp["id"]: {"count": 0} for wp in all_workproducts.values()}
 
     # Iterate over workflows and update the counts and workflows
-    for workflow_id, workflow in all_workflows.items():
+    for workflow in all_workflows.values():
         for output in workflow["output"]:
-            # If the workproduct is in the analysis, increment its count and add the workflow_id
+            # Increment count and add workflow_id if workproduct is in analysis
             if output in workproduct_analysis:
                 workproduct_analysis[output]["count"] += 1
 

--- a/docs/_tooling/extensions/score_metamodel/checks/traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/traceability.py
@@ -40,15 +40,19 @@
 #             formatted_parents_not_correct = ", ".join(
 #                 f"`{parent}`" for parent in parents_not_correct
 #             )
-#             msg = f"has a parent requirement(s): {formatted_parents_not_correct} with an invalid status."
+#             msg = (
+#                       f"has a parent requirement(s): {formatted_parents_not_correct} "
+#                       f"with an invalid status."
+#                   )
 #             log.warning_for_need(need, msg)
 #
 #
 # @graph_check
 # def check_linkage_safety(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
 #     """
-#     Checking if for feature, component and tool requirements it shall be checked if at least one parent requirement
-#     contains the same or lower ASIL compared to the ASIL of the current requirement then it will return False.
+#     Checking if for feature, component and tool requirements it shall be checked
+#     if at least one parent requirement contains the same or lower ASIL compared
+#     to the ASIL of the current requirement then it will return False.
 #     """
 #     # Convert list to dictionary for easy lookup
 #     needs_dict = {need["id"]: need for need in needs}
@@ -78,8 +82,10 @@
 #                 unsafe_parents.append(parent)
 #         if unsafe_parents:
 #             msg = (
-#                 f"`{need['id']}` parents: {unsafe_parents} have either no, or not allowed safety ASIL values. "
-#                 f"Allowed ASIL values: {', '.join(f'`{value}`' for value in allowed_values)}. \n"
+#                 f"`{need['id']}` parents: {unsafe_parents} have either no, or not "
+#                "allowed safety ASIL values. "
+#                 f"Allowed ASIL values: "
+#                 f"{', '.join(f'`{value}`' for value in allowed_values)}. \n"
 #             )
 #             log.warning_for_need(need, msg)
 #
@@ -87,7 +93,8 @@
 # @graph_check
 # def check_linkage_status(app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger):
 #     """
-#     Checking if for valid feature, component and tool requirements it shall be checked if the status of the parent requirement is also valid.
+#     Checking if for valid feature, component and tool requirements it shall be checked
+#     if the status of the parent requirement is also valid.
 #     """
 #     needs_dict = {need["id"]: need for need in needs}
 #     for need in needs:
@@ -96,5 +103,6 @@
 #                 parent_need = needs_dict.get(satisfie_need)  # Get parent requirement
 #
 #                 if not parent_need or parent_need.get("status") != "valid":
-#                     msg = f"has a valid status but one of its parents: `{satisfie_need}` has an invalid status. \n"
+#                     msg = f"has a valid status but one of its parents:
+#                     "`{satisfie_need}` has an invalid status. \n"
 #                     log.warning_for_need(need, msg)

--- a/docs/_tooling/extensions/score_metamodel/log.py
+++ b/docs/_tooling/extensions/score_metamodel/log.py
@@ -28,8 +28,9 @@ class CheckLogger:
             return need.get(key, None)
 
         if get("docname") and get("doctype") and get("lineno"):
-            # Note: passing the location as a string allows us to use readable relative paths,
-            # passing as a tuple results in absolute paths to ~/.cache/.../bazel-out/..
+            # Note: passing the location as a string allows us to use
+            # readable relative paths, passing as a tuple results
+            # in absolute paths to ~/.cache/.../bazel-out/..
             if "RUNFILES_DIR" in os.environ or "RUNFILES_MANIFEST_FILE" in os.environ:
                 matching_file = f"{need['docname']}{need['doctype']}"
             else:

--- a/docs/_tooling/extensions/score_metamodel/tests/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/__init__.py
@@ -13,8 +13,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-
-from sphinx.application import Sphinx
 from sphinx.util.logging import SphinxLoggerAdapter
 
 from docs._tooling.extensions.score_metamodel import CheckLogger, NeedsInfoType
@@ -39,10 +37,12 @@ def fake_check_logger():
 
         def assert_warning(self, expected_substring: str, expect_location=True):
             """
-            Assert that the logger was called exactly once with a message containing a specific substring.
+            Assert that the logger was called exactly once with a message containing
+            a specific substring.
 
             This also verifies that the defaults from need() are used correctly.
-            So you must use need() to create the need object that is passed to the checks.
+            So you must use need() to create the need object that is passed
+            to the checks.
             """
             self._mock_logger.warning.assert_called_once()
 

--- a/docs/_tooling/extensions/score_metamodel/tests/test_attributes_format.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_attributes_format.py
@@ -60,7 +60,9 @@ class TestId:
         check_id_format(app, need, logger)
 
         logger.assert_warning(
-            "expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`.",
+            "expected to consisting of one of these 2 formats:"
+            "`<Req Type>__<Abbreviations>` or "
+            "`<Req Type>__<Abbreviations>__<Architectural Element>`.",
             expect_location=False,
         )
 
@@ -79,7 +81,8 @@ class TestId:
         check_id_format(app, need, logger)
 
         logger.assert_warning(
-            "expected to consisting of this format: `<Req Type>__<Abbreviations>__<Architectural Element>`.",
+            "expected to consisting of this format: "
+            "`<Req Type>__<Abbreviations>__<Architectural Element>`.",
             expect_location=False,
         )
 
@@ -112,7 +115,8 @@ class TestId:
 
         check_id_length(app, need, logger)
         logger.assert_warning(
-            f'exceeds the maximum allowed length of 45 characters (current length: {len(need['id'])}).',
+            f"exceeds the maximum allowed length of 45 characters "
+            f"(current length: {len(need["id"])}).",
             expect_location=False,
         )
 
@@ -150,8 +154,9 @@ class TestId:
         check_title(app, need, logger)
         logger.assert_warning(
             (
-                "contains a stop word: `shall`. The title is meant to provide a short summary, "
-                "not to repeat the requirement statement. Please revise the title for clarity and brevity."
+                "contains a stop word: `shall`. The title is meant to provide a short "
+                "summary, not to repeat the requirement statement. Please revise "
+                "the title for clarity and brevity."
             ),
             expect_location=False,
         )

--- a/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
@@ -11,22 +11,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-from unittest.mock import Mock
+# from unittest.mock import Mock
 
-from sphinx.application import Sphinx
+# from sphinx.application import Sphinx
 from sphinx_needs.data import NeedsInfoType
 
 from docs._tooling.extensions.score_metamodel.checks import standards
-from docs._tooling.extensions.score_metamodel.tests import fake_check_logger
+
+# from docs._tooling.extensions.score_metamodel.tests import fake_check_logger
 
 
 class TestStandards:
-    #                    ╭──────────────────────────────────────────────────────────────────────────────╮
-    #                    │                             Disabled temporarly                              │
-    #                    ╰──────────────────────────────────────────────────────────────────────────────╯
-    #   def test_check_all_standard_req_linked_item_via_the_compliance_req_positive(self):
+    #                    ╭─────────────────────────────────────────────────────────────╮
+    #                    │                             Disabled temporarly             │
+    #                    ╰─────────────────────────────────────────────────────────────╯
+    #   def test_check_all_standard_req_linked_item_via_the_compliance_req_positive(
+    #       self
+    #   ):
     #        """
-    #        Test if check all_standard_req_linked_item_via_the_compliance_req function will give a False value (check is valid) when giving a standar requirement which is linked to at least one of the list of items that have complies tag via the same tag.
+    #        Test if check all_standard_req_linked_item_via_the_compliance_req
+    #        function will give a False value (check is valid) when giving a standar
+    #        requirement which is linked to at least one of the list of items that
+    #        have complies tag via the same tag.
     #        """
     #
     #        need_1 = NeedsInfoType(
@@ -69,7 +75,10 @@ class TestStandards:
 
     # def test_check_standard_req_linked_item_via_the_compliance_req_negative(self):
     #     """
-    #     Test if check all_standard_req_linked_item_via_the_compliance_req function will give a False value (check is invalid) when giving a standar requirement which is not linked to at least one of the list of items that have complies tag via the same tag.
+    #     Test if check all_standard_req_linked_item_via_the_compliance_req
+    #     function will give a False value (check is invalid) when giving a standar
+    #     requirement which is not linked to at least one of the list of items that
+    #     have complies tag via the same tag.
     #     """
 
     #     need_1 = NeedsInfoType(
@@ -109,7 +118,8 @@ class TestStandards:
     #         app, needs, logger
     #     )
     #     logger.assert_warning(
-    #         f"Standard requirement `{need_1['id']}` is not linked to at least one item via the complies tag.",
+    #         f"Standard requirement `{need_1['id']}` is not linked to at least one "
+    #         f"item via the complies tag.",
     #         expect_location=False,
     #     )
 
@@ -117,11 +127,14 @@ class TestStandards:
     #     self,
     # ):
     #     """
-    #     Test if check all_standard_workproducts_linked_item_via_the_compliance_wp function will give a False value (check is valid) when giving a standar workproduct which is linked to at least one of the list of items that have complies tag via the same tag.
+    #     Test if check all_standard_workproducts_linked_item_via_the_compliance_wp
+    #     function will give a False value (check is valid) when giving a standar
+    #     workproduct which is linked to at least one of the list of items that have
+    #     complies tag via the same tag.
     #     """
 
     #     need_1 = NeedsInfoType(
-    #         target_id="Organization-specific rules and processes for functional safety",
+    #         target_id="Organization-specific rules and processes for safety",
     #         id="std_wp__iso26262__wp-2-551",
     #         type="std_wp",
     #         status="valid",
@@ -158,11 +171,14 @@ class TestStandards:
     #     self,
     # ):
     #     """
-    #     Test if check all_standard_workproducts_linked_item_via_the_compliance_wp function will give a True value (check is invalid) when giving a standar workproduct which is not linked to at least one of the list of items that have complies tag via the same tag.
+    #     Test if check all_standard_workproducts_linked_item_via_the_compliance_wp
+    #     function will give a True value (check is invalid) when giving a standar
+    #     workproduct which is not linked to at least one of the list of items that
+    #     have complies tag via the same tag.
     #     """
 
     #     need_1 = NeedsInfoType(
-    #         target_id="Organization-specific rules and processes for functional safety",
+    #         target_id="Organization-specific rules and processes for safety",
     #         id="std_wp__iso26262__wp-2-551",
     #         type="std_wp",
     #         status="valid",
@@ -193,13 +209,17 @@ class TestStandards:
     #     )
 
     #     logger.assert_warning(
-    #         f"Standard workproduct `{need_1['id']}` is not linked to at least one item via the complies tag.",
+    #         f"Standard workproduct `{need_1['id']}` is not linked to at least one "
+    #         f"item via the complies tag.",
     #         expect_location=False,
     #     )
 
     # def test_check_workproduct_uniqueness_over_workflows_positive(self):
     #     """
-    #     Test if check check_workproduct_uniqueness_over_workflows function will give a False value (check is valid) when giving a workproduct which is linked exactly to one workflow least from the list of all workflows via output option.
+    #     Test if check check_workproduct_uniqueness_over_workflows function will give
+    #     a False value (check is valid) when giving a workproduct which is linked
+    #     exactly to one workflow least from the list of all workflows via
+    #     output option.
     #     """
     #     need_1 = NeedsInfoType(
     #         target_id="Module Safety Plan",
@@ -246,7 +266,10 @@ class TestStandards:
     #     self,
     # ):
     #     """
-    #     Test if check check_workproduct_uniqueness_over_workflows function will give a True value (check is invalid) when giving a workproduct which is linked exactly to no workflow from the list of all workflows via output option.
+    #     Test if check check_workproduct_uniqueness_over_workflows function will
+    #     give a True value (check is invalid) when giving a workproduct which is
+    #     linked exactly to no workflow from the list of all workflows via
+    #     output option.
     #     """
 
     #     need_1 = NeedsInfoType(
@@ -299,7 +322,10 @@ class TestStandards:
     #     self,
     # ):
     #     """
-    #     Test if check check_workproduct_uniqueness_over_workflows function will give a True value (check is invalid) when giving a workproduct which is linked exactly to more then one workflow from the list of all workflows via output option.
+    #     Test if check check_workproduct_uniqueness_over_workflows function will
+    #     give a True value (check is invalid) when giving a workproduct which is
+    #     linked exactly to more then one workflow from the list of all workflows
+    #     via output option.
     #     """
 
     #     need_1 = NeedsInfoType(
@@ -368,13 +394,15 @@ class TestStandards:
     #         f"is contained in {2} workflows: {workflows_str}, which is incorrect.",
     #         expect_location=False,
     #     )
-    #                    ╭──────────────────────────────────────────────────────────────────────────────╮
-    #                    │                            END OF TEMP DISABLING                             │
-    #                    ╰──────────────────────────────────────────────────────────────────────────────╯
+    #                    ╭─────────────────────────────────────────────────────────────╮
+    #                    │                            END OF TEMP DISABLING            │
+    #                    ╰─────────────────────────────────────────────────────────────╯
 
     def test_my_pie_linked_standard_requirements(self):
         """
-        Simulate results  for my_pie_linked_standard_requirements function and check if the result parameter after calling this function a special case will give the correct value.
+        Simulate results  for my_pie_linked_standard_requirements function and
+        check if the result parameter after calling this function a special case
+        will give the correct value.
         """
         needs = {}
 
@@ -433,11 +461,13 @@ class TestStandards:
 
     def test_my_pie_linked_standard_workproducts(self):
         """
-        Simulate results  for test_my_pie_linked_standard_workproducts function and check if the result parameter after calling this function with a special case will give the correct value.
+        Simulate results  for test_my_pie_linked_standard_workproducts function
+        and check if the result parameter after calling this function with
+        a special case will give the correct value.
         """
 
         need_1 = NeedsInfoType(
-            target_id="Organization-specific rules and processes for functional safety",
+            target_id="Organization-specific rules and processes for safety",
             id="std_wp__iso26262__wp-2-551",
             type="std_wp",
             status="valid",
@@ -485,7 +515,9 @@ class TestStandards:
 
     def test_my_pie_workproducts_contained_in_exactly_one_workflow(self):
         """
-        Simulate results  for test_my_pie_workproducts_contained_in_exactly_one_workflow function and check if the result parameter after calling this function with a special case will give the correct value.
+        Simulate results  for test_my_pie_workproducts_contained_in_exactly_one_workflow
+        function and check if the result parameter after calling this function with
+        a special case will give the correct value.
         """
 
         need_1 = NeedsInfoType(
@@ -597,9 +629,12 @@ class TestStandards:
         standards.my_pie_workproducts_contained_in_exactly_one_workflow(needs, results)
 
         # Check that results are [1, 1]
-        assert (
-            results == [1, 1, 1]
-        ), f"For function my_pie_workproducts_contained_in_exactly_one_workflow expected [1, 1, 1] but got {
+        assert results == [
+            1,
+            1,
+            1,
+        ], "For function my_pie_workproducts_contained_in_exactly_one_workflow expected"
+        f"[1, 1, 1] but got {
             results
         }"
 
@@ -635,10 +670,11 @@ class TestStandards:
 
     def test_get_standards_workproducts(self):
         """
-        Test if get_standards_workproducts works as expected with a positive and negative test.
+        Test if get_standards_workproducts works as expected with a
+        positive and negative test.
         """
         need_1 = NeedsInfoType(
-            target_id="Organization-specific rules and processes for functional safety",
+            target_id="Organization-specific rules and processes for safety",
             id="std_wp__iso26262__wp-2-551",
             type="std_wp",
             status="valid",
@@ -664,7 +700,8 @@ class TestStandards:
 
     def test_get_compliance_req_needs(self):
         """
-        Test if get_compliance_req_needs works as expected with a positive and negative test.
+        Test if get_compliance_req_needs works as expected with a positive
+        and negative test.
         """
 
         need_1 = NeedsInfoType(
@@ -711,7 +748,8 @@ class TestStandards:
 
     def test_get_compliance_wp_needs(self):
         """
-        Test if get_compliance_wp_needs works as expected with a positive and negative test.
+        Test if get_compliance_wp_needs works as expected with a positive and
+        negative test.
         """
 
         need_1 = NeedsInfoType(

--- a/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_traceability.py
@@ -84,7 +84,8 @@
 #         check_linkage_parent(app, needs, logger)
 #
 #         logger.assert_warning(
-#             f"has a parent requirement(s): `{need_1['satisfies'][0]}` with an invalid status.",
+#             f"has a parent requirement(s): `{need_1['satisfies'][0]}` with an "
+#             f"invalid status.",
 #             expect_location=False,
 #         )
 #
@@ -143,7 +144,8 @@
 #
 #         check_linkage_safety(app, needs, logger)
 #         logger.assert_warning(
-#             f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_D`.",
+#             f"with `{need_1['safety']}` has no parent requirement that contains "
+#             f"the same or lower ASIL. Allowed ASIL values: `ASIL_D`.",
 #             expect_location=False,
 #         )
 #
@@ -167,7 +169,8 @@
 #
 #         check_linkage_safety(app, needs, logger)
 #         logger.assert_warning(
-#             f"with `{need_1['safety']}` has no parent requirement that contains the same or lower ASIL. Allowed ASIL values: `ASIL_B`, `ASIL_D`.",
+#             f"with `{need_1['safety']}` has no parent requirement that contains "
+#             f"the same or lower ASIL. Allowed ASIL values: `ASIL_B`, `ASIL_D`.",
 #             expect_location=False,
 #         )
 #
@@ -220,6 +223,7 @@
 #         check_linkage_status(app, needs, logger)
 #
 #         logger.assert_warning(
-#             "has a valid status but one of its parents: `feat_req__3` has an invalid status.",
+#             "has a valid status but one of its parents: `feat_req__3` has an "
+#              "invalid status.",
 #             expect_location=False,
 #         )

--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -69,7 +69,8 @@ def add_source_link(app: Sphinx, env) -> None:
                         x.replace(GITHUB_BASE_URL, "").split("/", 1)[-1] for x in link
                     ]
                     LOGGER.warning(
-                        f"Could not find {id} in the needs id's. Found in file(s): {files}",
+                        f"Could not find {id} in the needs id's. "
+                        f"Found in file(s): {files}",
                         type="score_source_code_linker",
                     )
         except Exception as e:


### PR DESCRIPTION
Fix ruff and pylance errors in the score_metamode folder.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

Related to. #531 