### PR TITLE
docs: Add vscode spell check extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -14,5 +14,8 @@
 
         // Linting and formatting for Python (LSP via ruff server)
         "charliermarsh.ruff",
+
+        // Code Spell checker
+        "streetsidesoftware.code-spell-checker",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,5 +84,26 @@
       "//tools/starpls:starpls",
       "--"
     ],
-    "cSpell.enabledFileTypes": {"rst": true}
+    "cSpell.enabledFileTypes": {
+        "rst": true
+    },
+    "cSpell.words": [
+        "__getitem__",
+        "bazel",
+        "metatags",
+        "getstrt",
+        "reqs"
+    ],
+    "cSpell.ignoreRegExpList": [
+        "/:\\w+:\\s+[`]?[^`,\n]+(?:,\\s*[^`,\n]+)*[`]?/", //ignore any words following :text:
+        "/:\\w+:\\s*`[^`]+`/", //ignore any words following :text: inside backticks also
+        "/\\.\\.\\s+\\w+::\\s+[`]?[^`,\\n]+(?:,\\s*[^`,\\n]+)*[`]?/", //ignore any words following .. text::
+        "/workproduct(s)?/i", //ignore workproduct word and variations
+        "/metamodel(s)?/i", //ignore metamodels word and variations
+        "/memcheck?/i", //ignore memcheck word and variations
+        "/\\.\\.\\s+\\w+/", //ignore .. word
+        "/``[^`]+``/", //ignore words between double backticks
+        "/\\*?need[a-zA-Z0-9_()]*\\*?/i", // ignore *needSomeWord*
+        "/\\b[A-Z]+(?:_[A-Z]+)*\\b/", //ignore all CAPS, also if includes underscore
+      ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "editor.rulers": [
         99
     ],
-
     "[python]": {
         // In python using 80 characters per line is the standard.
         "editor.rulers": [
@@ -84,5 +83,6 @@
       "run",
       "//tools/starpls:starpls",
       "--"
-    ]
+    ],
+    "cSpell.enabledFileTypes": {"rst": true}
 }


### PR DESCRIPTION
# Improvement

## Description

After reviewing the `process `documentation it seems that there are a lot of spell mistakes so I added the VSCode extension for rst spell checking.

## Related ticket


related #544   (improvement ticket)