### PR TITLE
process: add testing community role

### DIFF
--- a/docs/process/process_areas/verification/verification_roles.rst
+++ b/docs/process/process_areas/verification/verification_roles.rst
@@ -30,6 +30,6 @@ With focus on testability, requirements getting reviewed by:
 
    * :need:`rl__testing_community`
 
-The tool evaluation, verification and reporting is handled by:
+The tool verification and qualification is handled by:
 
    * :need:`rl__infrastructure_tooling_community`.

--- a/docs/process/process_areas/verification/verification_roles.rst
+++ b/docs/process/process_areas/verification/verification_roles.rst
@@ -17,12 +17,18 @@
 Roles
 #####
 
-For verification activities no additional roles need to be defined.
+Verification activities are a shared effort by :need:`Contributor <rl__contributor>` as well as
+:need:`Committer <rl__committer>`. There is also a dedicated :need:`Testing Community <rl__testing_community>`
+which develops and reviews tests and is involved in the requirements review.
 
-Verification artifacts in form of test cases and specification are created by:
+Verification artifacts in form of test cases and specification are mainly created by:
 
    * :need:`rl__contributor`
    * :need:`rl__committer`
+
+With focus on testability, requirements getting reviewed by:
+
+   * :need:`rl__testing_community`
 
 The tool evaluation, verification and reporting is handled by:
 

--- a/docs/process/process_areas/verification/workflows.rst
+++ b/docs/process/process_areas/verification/workflows.rst
@@ -43,7 +43,7 @@ Workflow Verification
    :status: valid
    :tags: verification
    :responsible: rl__contributor
-   :approved_by: rl__committer
+   :approved_by: rl__committer, rl__testing_community
    :supported_by: rl__safety_manager
    :input: wp__requirements__comp, wp__requirements__comp_aou, wp__verification__plan
    :output: wp__verification__component_test
@@ -62,7 +62,7 @@ Workflow Verification
    :status: valid
    :tags: verification
    :responsible: rl__contributor
-   :approved_by: rl__committer
+   :approved_by: rl__committer, rl__testing_community
    :supported_by: rl__safety_manager
    :input: wp__component_arch, wp__sw_implementation, wp__verification__plan
    :output: wp__verification__comp_int_test
@@ -81,7 +81,7 @@ Workflow Verification
    :status: valid
    :tags: verification
    :responsible: rl__contributor
-   :approved_by: rl__committer
+   :approved_by: rl__committer, rl__testing_community
    :supported_by: rl__safety_manager
    :input: wp__feature_arch, wp__requirements__feat, wp__requirements__feat_aou,
            wp__verification__plan
@@ -101,7 +101,7 @@ Workflow Verification
    :status: valid
    :tags: verification
    :responsible: rl__contributor
-   :approved_by: rl__committer
+   :approved_by: rl__committer, rl__testing_community
    :supported_by: rl__safety_manager
    :input: wp__requirements__stkh, wp__verification__plan
    :output: wp__verification__platform_test
@@ -119,7 +119,7 @@ Workflow Verification
    :id: wf__verification__plan
    :status: valid
    :tags: verification
-   :responsible: rl__committer
+   :responsible: rl__committer, rl__testing_community
    :approved_by: rl__technical_lead
    :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
    :input: wp__requirements__stkh, wp__platform_mgmt, wp__tool_eval
@@ -136,7 +136,7 @@ Workflow Verification
    :id: wf__verification__plan_maintain
    :status: valid
    :tags: verification
-   :responsible: rl__committer
+   :responsible: rl__committer, rl__testing_community
    :approved_by: rl__technical_lead
    :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
    :input: wp__verification__plan, wp__requirements__stkh, wp__platform_mgmt,
@@ -158,7 +158,7 @@ Workflow Verification
    :id: wf__verification__mod_ver_report
    :status: valid
    :tags: verification
-   :responsible: rl__committer
+   :responsible: rl__committer, rl__testing_community
    :approved_by: rl__technical_lead
    :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
    :input: wp__verification__plan, wp__requirements__comp, wp__requirements__comp_aou,
@@ -182,7 +182,7 @@ Workflow Verification
    :id: wf__verification__platform_ver_report
    :status: valid
    :tags: verification
-   :responsible: rl__committer
+   :responsible: rl__committer, rl__testing_community
    :approved_by: rl__technical_lead
    :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
    :input: wp__verification__plan, wp__requirements__stkh, wp__requirements__feat, wp__requirements__feat_aou,

--- a/docs/process/roles/index.rst
+++ b/docs/process/roles/index.rst
@@ -153,7 +153,7 @@ SCORE development roles
    The testing community members are responsible for the test case development from component to
    platform level. They shall be included in any requirements reviews. They can also improve
    independence argumentation when involved in the development of unit testing on safety critical
-   units.
+   units. In this way the testing community takes a supportive role for unit testing
 
 
 SCORE cross functional teams
@@ -173,4 +173,4 @@ SCORE cross functional teams
    :tags: cross_functional
    :contains: rl__module_lead, rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer
 
-   The module team is responsible for all artefacts within the module SEooCs. Each module has only one responsible team but a team may also be responsible for several (small) modules.
+   The module team is responsible for all artifacts within the module SEooCs. Each module has only one responsible team but a team may also be responsible for several (small) modules.

--- a/docs/process/roles/index.rst
+++ b/docs/process/roles/index.rst
@@ -144,6 +144,18 @@ SCORE development roles
    .. note::
       Defines and enforces processes.
 
+.. role:: Testing Community Member
+   :id: rl__testing_community
+   :status: valid
+   :tags: verification
+   :contains: rl__committer
+
+   The testing community members are responsible for the test case development from component to
+   platform level. They shall be included in any requirements reviews. They can also improve
+   independence argumentation when involved in the development of unit testing on safety critical
+   units.
+
+
 SCORE cross functional teams
 ----------------------------
 
@@ -153,7 +165,7 @@ SCORE cross functional teams
    :tags: cross_functional
    :contains: rl__technical_lead, rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer, rl__infrastructure_tooling_community, rl__process_community
 
-   The platform team is responsible for all artefacts within the platform SEooC. Additionally it is also responsible for the overall process including its support by tooling.
+   The platform team is responsible for all artifacts within the platform SEooC. Additionally it is also responsible for the overall process including its support by tooling.
 
 .. role:: Module Team
    :id: rl__module_team
@@ -162,4 +174,3 @@ SCORE cross functional teams
    :contains: rl__module_lead, rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer
 
    The module team is responsible for all artefacts within the module SEooCs. Each module has only one responsible team but a team may also be responsible for several (small) modules.
-


### PR DESCRIPTION
During the 3rd interim audit, the demand was formulated, that we need to have a verification specific role, which could be filled by the existing testing community. This is added by this PR.

closes: Improvement: Testing Community Role #777