### PR TITLE
tooling: Fix pyright errors in tooling

### DIFF
--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -60,7 +60,8 @@ def add_source_link(app: Sphinx, env) -> None:
                     # the needs gets 're-evaluated'.
                     need = needs_copy[id]  # NeedsInfoType
                     Needs_Data.remove_need(need["id"])
-                    need["source_code_link"] = ",".join(link)
+                    # extra_options are only available at runtime
+                    need["source_code_link"] = ",".join(link)  # type: ignore
                     Needs_Data.add_need(need)
                 except KeyError:
                     # NOTE: manipulating link to remove git-hash,

--- a/docs/_tooling/extensions/score_source_code_linker/tests/test_source_link.py
+++ b/docs/_tooling/extensions/score_source_code_linker/tests/test_source_link.py
@@ -129,13 +129,14 @@ def test_source_link_integration_ok(
         needs_data = {x["id"]: x for x in Needs_Data.get_needs_view().values()}
         assert "TREQ_ID_1" in needs_data
         assert "TREQ_ID_2" in needs_data
+        # extra_options are only available at runtime
         assert (
             ",".join(example_source_link_text_all_ok["TREQ_ID_1"])
-            == needs_data["TREQ_ID_1"]["source_code_link"]
+            == needs_data["TREQ_ID_1"]["source_code_link"]  # type: ignore
         )
         assert (
             ",".join(example_source_link_text_all_ok["TREQ_ID_2"])
-            == needs_data["TREQ_ID_2"]["source_code_link"]
+            == needs_data["TREQ_ID_2"]["source_code_link"]  # type: ignore
         )
     finally:
         app.cleanup()

--- a/docs/_tooling/incremental.py
+++ b/docs/_tooling/incremental.py
@@ -11,17 +11,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-import os
 import argparse
-import debugpy
 import logging
+import os
 import sys
-
 from pathlib import Path
-from python.runfiles import Runfiles
+
+import debugpy
+from python.runfiles import Runfiles  # type: ignore
 from sphinx.cmd.build import main as sphinx_main
 from sphinx_autobuild.__main__ import main as sphinx_autobuild_main
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix pyright errors in _tooling and score_source_code_linker by suppressing type errors in the code.

Fixes: https://github.com/eclipse-score/score/issues/531