### PR TITLE
cicd: bugfix

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -28,3 +28,5 @@ jobs:
     uses: eclipse-score/cicd-workflows/.github/workflows/license-check.yml@main
     with:
       repo-url: "${{ github.server_url }}/${{ github.repository }}"
+    secrets:
+      dash-api-token: ${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}


### PR DESCRIPTION
Even if ECLIPSE_GITLAB_API_TOKEN is set as an organization secret, it won’t be automatically available inside a reusable workflow. Reusable workflows are not automatically given access to secrets from the caller's context ( not even org secrets).

Addresses: #813