### PR TITLE
tooling: Reduce 2 types of Pylance new warnings and more

### DIFF
--- a/docs/_tooling/extensions/score_draw_uml_funcs/__init__.py
+++ b/docs/_tooling/extensions/score_draw_uml_funcs/__init__.py
@@ -29,6 +29,7 @@ import hashlib
 import time
 from functools import cache
 from pathlib import Path
+from typing import Any, Callable
 
 from sphinx.application import Sphinx
 from sphinx_needs.logging import get_logger
@@ -50,7 +51,7 @@ from score_draw_uml_funcs.helpers import (
 logger = get_logger(__file__)
 
 
-def setup(app: Sphinx) -> dict:
+def setup(app: Sphinx) -> dict[str, object]:
     app.config.needs_render_context = draw_uml_function_context
     return {
         "version": "0.1",
@@ -85,10 +86,10 @@ def scripts_directory_hash():
 
 def draw_comp_incl_impl_int(
     need: dict[str, str],
-    all_needs: dict[str, dict],
+    all_needs: dict[str, dict[str, Any]],
     proc_impl_interfaces: dict[str, str],
-    proc_used_interfaces: dict[str, list],
-) -> tuple[str, str, dict[str, str], dict[str, list]]:
+    proc_used_interfaces: dict[str, list[str]],
+) -> tuple[str, str, dict[str, str], dict[str, list[str]]]:
     # Draw outer component
     structure_text = f"{gen_struct_element('component', need)}  {{\n"
     linkage_text = ""
@@ -129,7 +130,7 @@ def draw_comp_incl_impl_int(
             logger.info(f"{need}: implements {iface} could not be found")
             continue
 
-        if not (interface := proc_impl_interfaces.get(iface, [])):
+        if not proc_impl_interfaces.get(iface, []):
             structure_text += gen_interface_element(iface, all_needs, True)
             linkage_text += f"{
                 gen_link_text(
@@ -148,7 +149,7 @@ def draw_comp_incl_impl_int(
             logger.info(f"{need}: uses {iface} could not be found")
             continue
 
-        if not (interface := proc_used_interfaces.get(iface, [])):
+        if not proc_used_interfaces.get(iface, []):
             proc_used_interfaces[iface] = [need["id"]]
         else:
             proc_used_interfaces[iface].append(need["id"])
@@ -158,7 +159,7 @@ def draw_comp_incl_impl_int(
 
 def draw_module(
     need: dict[str, str],
-    all_needs: dict[str, dict],
+    all_needs: dict[str, dict[str, Any]],
 ) -> tuple[str, str]:
     """
     Drawing and parsing function of a component.
@@ -247,7 +248,7 @@ def draw_module(
     structure_text += f"}} /' {need['title']} '/ \n\n"
 
     # Add logical interfaces only to implemented interfaces
-    for iface, component in proc_impl_interfaces.items():
+    for iface, _ in proc_impl_interfaces.items():
         if not (proc_logical_interfaces.get(iface, [])):
             # Currently only one Logical Interface per Real Interface supported
             logical_iface_tmp = get_logical_interface_real(iface, all_needs)
@@ -316,7 +317,9 @@ class draw_full_feature:
     def __repr__(self):
         return "draw_full_feature" + " in " + scripts_directory_hash()
 
-    def __call__(self, need, all_needs: dict) -> str:
+    def __call__(
+        self, need: dict[str, Any], all_needs: dict[str, dict[str, Any]]
+    ) -> str:
         interfacelist = []
         impl_comp = dict()
 
@@ -382,7 +385,9 @@ class draw_full_module:
     def __repr__(self):
         return "draw_full_module" + " in " + scripts_directory_hash()
 
-    def __call__(self, need, all_needs) -> str:
+    def __call__(
+        self, need: dict[str, Any], all_needs: dict[str, dict[str, Any]]
+    ) -> str:
         structure_text, linkage_text = draw_module(need, all_needs)
 
         return gen_header() + structure_text + linkage_text
@@ -392,9 +397,11 @@ class draw_full_component:
     def __repr__(self):
         return "draw_full_component" + " in " + scripts_directory_hash()
 
-    def __call__(self, need, all_needs) -> str:
-        structure_text, linkage_text, processed_interfaces, logical_interfacelist = (
-            draw_comp_incl_impl_int(need, all_needs, dict(), dict())
+    def __call__(
+        self, need: dict[str, Any], all_needs: dict[str, dict[str, Any]]
+    ) -> str:
+        structure_text, linkage_text, _, _ = draw_comp_incl_impl_int(
+            need, all_needs, dict(), dict()
         )
 
         return gen_header() + structure_text + linkage_text
@@ -404,13 +411,17 @@ class draw_full_interface:
     def __repr__(self):
         return "draw_full_interface" + " in " + scripts_directory_hash()
 
-    def __call__(self, need, all_needs) -> str:
+    def __call__(
+        self, need: dict[str, Any], all_needs: dict[str, dict[str, Any]]
+    ) -> str:
         structure_text = gen_interface_element(need["id"], all_needs, True)
 
         return structure_text + "\n"
 
 
-draw_uml_function_context = {
+CallableType = Callable[[dict[str, Any], dict[str, dict[str, Any]]], str]
+
+draw_uml_function_context: dict[str, CallableType] = {
     "draw_interface": draw_full_interface(),
     "draw_module": draw_full_module(),
     "draw_component": draw_full_component(),

--- a/docs/_tooling/extensions/score_draw_uml_funcs/helpers.py
+++ b/docs/_tooling/extensions/score_draw_uml_funcs/helpers.py
@@ -10,6 +10,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+from typing import Any
+
+
 def gen_need_link(need: dict[str, str]) -> str:
     """Generate the link to the need element from the PlantUML Diagram"""
     link = ".." + "/" + need["docname"] + ".html#" + need["id_parent"]
@@ -69,7 +72,7 @@ def gen_struct_element(UMLelement: str, need: dict[str, str]) -> str:
 
 
 def gen_interface_element(
-    need_id: str, all_needs: dict[str, dict], incl_ops: bool = False
+    need_id: str, all_needs: dict[str, dict[str, Any]], incl_ops: bool = False
 ) -> str:
     """Generate interface text and include all operations if selected."""
 
@@ -108,7 +111,9 @@ def gen_link_text(
     return f"{gen_alias(from_need)} {link_type} {gen_alias(to_need)}: {link_text}"
 
 
-def get_module(component: str, all_needs: dict[str, dict]) -> tuple[str, str, str, str]:
+def get_module(
+    component: str, all_needs: dict[str, dict[str, Any]]
+) -> tuple[str, str, str, str]:
     need = all_needs[component]
 
     open_text = ""
@@ -147,7 +152,7 @@ def get_module(component: str, all_needs: dict[str, dict]) -> tuple[str, str, st
 
 
 def get_interface_from_component(
-    component: dict[str, str], relation: str, all_needs: dict[str, dict]
+    component: dict[str, str], relation: str, all_needs: dict[str, dict[str, Any]]
 ) -> list[str]:
     local_interfaces = []
 
@@ -159,7 +164,7 @@ def get_interface_from_component(
     return local_interfaces
 
 
-def get_interface_from_int(need_id: str, all_needs: dict[str, dict]) -> str:
+def get_interface_from_int(need_id: str, all_needs: dict[str, dict[str, Any]]) -> str:
     """Get Interface for a provided Interface or Interface Operation"""
     if "_int_op" in all_needs[need_id]["type"]:
         iface = all_needs[need_id]["included_by"][0]
@@ -169,7 +174,9 @@ def get_interface_from_int(need_id: str, all_needs: dict[str, dict]) -> str:
     return iface
 
 
-def get_real_interface_logical(logical_interface_id: str, all_needs: dict) -> list[str]:
+def get_real_interface_logical(
+    logical_interface_id: str, all_needs: dict[str, dict[str, Any]]
+) -> list[str]:
     """Get real interface for provided logical interface
     The relation is traced via the interface operations
     """
@@ -188,7 +195,7 @@ def get_real_interface_logical(logical_interface_id: str, all_needs: dict) -> li
 
 
 def get_logical_interface_real(
-    real_interface_id: str, all_needs: dict[str, dict]
+    real_interface_id: str, all_needs: dict[str, dict[str, Any]]
 ) -> list[str]:
     """Get logical interface based on real interface"""
     logical_ifaces = list()
@@ -214,7 +221,9 @@ def get_logical_interface_real(
     return logical_ifaces
 
 
-def get_impl_comp_from_real_iface(real_iface: str, all_needs: dict[str, dict]) -> str:
+def get_impl_comp_from_real_iface(
+    real_iface: str, all_needs: dict[str, dict[str, Any]]
+) -> str:
     """Get implementing component of the interface"""
 
     implcomp = all_needs[real_iface].get("implements_back", [])
@@ -228,7 +237,7 @@ def get_impl_comp_from_real_iface(real_iface: str, all_needs: dict[str, dict]) -
 
 
 def get_use_comp_from_real_iface(
-    real_iface: str, all_needs: dict[str, dict]
+    real_iface: str, all_needs: dict[str, dict[str, Any]]
 ) -> list[str]:
     """Get components which use the interface"""
     usecomp = all_needs[real_iface].get("uses_back", [])

--- a/docs/_tooling/extensions/score_header_service/header_service.py
+++ b/docs/_tooling/extensions/score_header_service/header_service.py
@@ -10,12 +10,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-from collections import defaultdict
+import hashlib
 import os
+import random
 import re
 import subprocess
-import hashlib
-import random
+from collections import defaultdict
 from typing import Any
 
 from github import (
@@ -26,11 +26,11 @@ from github import (
     PullRequestReview,
     Repository,
 )
-from sphinx_needs.services.base import BaseService
-from sphinx.environment import BuildEnvironment
-from sphinx_needs.data import SphinxNeedsData
 from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
 from sphinx.util.docutils import SphinxDirective
+from sphinx_needs.data import SphinxNeedsData
+from sphinx_needs.services.base import BaseService
 
 # req-traceability: GD__automatic_document_header_generation
 APPROVER_TEAMS = ["automotive-score-committers"]
@@ -155,7 +155,7 @@ def _extract_merge_commit_data(location: str) -> dict[str, str | list[str]]:
     hash = lines[0]
     author = lines[1]
 
-    data: defaultdict[str, list] = defaultdict(list)
+    data: defaultdict[str, list[str]] = defaultdict(list)
 
     pattern = r"(Approved|Reviewed): \{(.*)} \( \{(.*)\} \) on \{(.*)\}"
 

--- a/docs/_tooling/extensions/score_layout/html_options.py
+++ b/docs/_tooling/extensions/score_layout/html_options.py
@@ -13,7 +13,7 @@
 from sphinx.application import Sphinx
 
 
-def return_html_theme_options(app: Sphinx) -> dict:
+def return_html_theme_options(app: Sphinx) -> dict[str, object]:
     return {
         "navbar_align": "content",
         "header_links_before_dropdown": 5,

--- a/docs/_tooling/extensions/score_metamodel/checks/standards.py
+++ b/docs/_tooling/extensions/score_metamodel/checks/standards.py
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 # from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType
+from typing import Any
 
 # from score_metamodel import (
 #    CheckLogger,
@@ -19,7 +19,7 @@ from sphinx_needs.data import NeedsInfoType
 # )
 
 
-def get_standards_needs(needs: list[NeedsInfoType]) -> dict:
+def get_standards_needs(needs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Return a dictionary of all standard requirements from the Sphinx app's needs.
     """
@@ -27,7 +27,9 @@ def get_standards_needs(needs: list[NeedsInfoType]) -> dict:
     return {need["id"]: need for need in needs if need["type"] == "std_req"}
 
 
-def get_standards_workproducts(needs: list[NeedsInfoType]) -> dict:
+def get_standards_workproducts(
+    needs: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     """
     Return a dictionary of standard workproducts from the Sphinx app's needs.
     """
@@ -35,7 +37,7 @@ def get_standards_workproducts(needs: list[NeedsInfoType]) -> dict:
     return {need["id"]: need for need in needs if need["type"] == "std_wp"}
 
 
-def get_workflows(needs: list[NeedsInfoType]) -> dict:
+def get_workflows(needs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Return a dictionary of all workflows from the Sphinx app's needs.
     """
@@ -43,7 +45,7 @@ def get_workflows(needs: list[NeedsInfoType]) -> dict:
     return {need["id"]: need for need in needs if need.get("type") == "workflow"}
 
 
-def get_workproducts(needs: list[NeedsInfoType]) -> dict:
+def get_workproducts(needs: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Return a dictionary of all workproducts from the Sphinx app's needs.
     """
@@ -51,7 +53,7 @@ def get_workproducts(needs: list[NeedsInfoType]) -> dict:
     return {need["id"]: need for need in needs if need.get("type") == "workproduct"}
 
 
-def get_compliance_req_needs(needs) -> set:
+def get_compliance_req_needs(needs: list[dict[str, Any]]) -> set[str]:
     """
     Return a set of all compliance_req values from the Sphinx app's needs,
     but only if the need type is one of the specified process-related types.
@@ -65,7 +67,7 @@ def get_compliance_req_needs(needs) -> set:
     }
 
 
-def get_compliance_wp_needs(needs) -> set:
+def get_compliance_wp_needs(needs: list[dict[str, Any]]) -> set[str]:
     """
     Return a set of all compliance_wp values from the Sphinx app's needs,
     but only if the need type is "workproduct".
@@ -84,7 +86,7 @@ def get_compliance_wp_needs(needs) -> set:
 #        ╰─────────────────────────────────────────────────────────────────────────────╯
 # @graph_check
 # def check_all_standard_req_linked_item_via_the_compliance_req(
-#     app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger
+#     app: Sphinx, needs: list[dict[str, Any]], log: CheckLogger
 # ):
 #     """
 #     Checks if all standard requirements are linked to an item via the compliance_req
@@ -104,7 +106,7 @@ def get_compliance_wp_needs(needs) -> set:
 #
 # @graph_check
 # def check_all_standard_workproducts_linked_item_via_the_compliance_wp(
-#     app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger
+#     app: Sphinx,needs: list[dict[str, Any]], log: CheckLogger
 # ):
 #     """
 #     Checks if all standard work products are linked to an item via the complies tag.
@@ -124,7 +126,7 @@ def get_compliance_wp_needs(needs) -> set:
 #
 # @graph_check
 # def check_workproduct_uniqueness_over_workflows(
-#     app: Sphinx, needs: list[NeedsInfoType], log: CheckLogger
+#     app: Sphinx,needs: list[dict[str, Any]], log: CheckLogger
 # ):
 #     """
 #     Check if all workproducts are contained in exactly one workflow.
@@ -173,7 +175,9 @@ def get_compliance_wp_needs(needs) -> set:
 #        ╰─────────────────────────────────────────────────────────────────────────────╯
 
 
-def my_pie_linked_standard_requirements(needs, results, **kwargs):
+def my_pie_linked_standard_requirements(
+    needs: list[dict[str, Any]], results: list[int], **kwargs: str | int | float
+) -> None:
     """
     Function to render the chart of check for standard requirements linked
     to at least an item via compliance-gd.
@@ -204,7 +208,9 @@ def my_pie_linked_standard_requirements(needs, results, **kwargs):
     results.append(cnt_not_connected)
 
 
-def my_pie_linked_standard_workproducts(needs, results, **kwargs):
+def my_pie_linked_standard_workproducts(
+    needs: list[dict[str, Any]], results: list[int], **kwargs: str | int | float
+) -> None:
     """
     Function to render the chart of check for standar workproducts linked
     to at least an item via compliance-wp.
@@ -236,7 +242,9 @@ def my_pie_linked_standard_workproducts(needs, results, **kwargs):
     results.append(cwp_not_connected)
 
 
-def my_pie_workproducts_contained_in_exactly_one_workflow(needs, results, **kwargs):
+def my_pie_workproducts_contained_in_exactly_one_workflow(
+    needs: list[dict[str, Any]], results: list[int], **kwargs: str | int | float
+) -> None:
     """
     Function to render the chart of check for workproducts that are contained
     in exactly one workflow, the not connected once and the once

--- a/docs/_tooling/extensions/score_metamodel/tests/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/__init__.py
@@ -35,7 +35,7 @@ def fake_check_logger():
                 )
                 pytest.fail(f"Expected no warnings, but got:\n{warnings}")
 
-        def assert_warning(self, expected_substring: str, expect_location=True):
+        def assert_warning(self, expected_substring: str, expect_location: bool = True):
             """
             Assert that the logger was called exactly once with a message containing
             a specific substring.

--- a/docs/_tooling/extensions/score_source_code_linker/__init__.py
+++ b/docs/_tooling/extensions/score_source_code_linker/__init__.py
@@ -22,7 +22,7 @@ from score_source_code_linker.parse_source_files import GITHUB_BASE_URL
 LOGGER = get_logger(__name__)
 
 
-def setup(app: Sphinx) -> dict:
+def setup(app: Sphinx) -> dict[str, str | bool]:
     app.add_config_value("source_code_linker_file", "", rebuild="env")
     if app.config.source_code_linker_file:
         LOGGER.info("Loading source code linker...", type="score_source_code_linker")

--- a/docs/_tooling/extensions/score_source_code_linker/parse_source_files.py
+++ b/docs/_tooling/extensions/score_source_code_linker/parse_source_files.py
@@ -64,8 +64,8 @@ def get_git_hash(file_path: str) -> str:
 
 def extract_requirements(
     source_file: str,
-    git_hash_func: Callable | None = get_git_hash,
-) -> dict[str, list]:
+    git_hash_func: Callable[[str], str] | None = get_git_hash,
+) -> dict[str, list[str]]:
     """
     This extracts the file-path, lineNr as well as the git hash of the file
     where a tag was found.

--- a/docs/_tooling/incremental.py
+++ b/docs/_tooling/incremental.py
@@ -37,7 +37,7 @@ if args.debug:
     pass
 
 
-def get_env(name):
+def get_env(name: str) -> str:
     val = os.environ.get(name, None)
     logger.debug(f"Env: {name} = {val}")
     if val is None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@
 
 import os
 import sys
+from typing import Any
 
 # sys.path extension for local files is needed, because the conf.py file is not
 # executed, but imported by Sphinx
@@ -67,7 +68,7 @@ numfig = True
 needs_template_folder = "_templates"
 needs_global_options = {"collapse": True}
 html_static_path = ["_tooling/assets", "_assets"]
-needs_string_links = {
+needs_string_links: dict[str, dict[str, Any]] = {
     "source_code_linker": {
         "regex": r"(?P<value>[^,]+)",
         "link_url": "{{value}}",

--- a/tools/testing/pytest/tests/test_rules_are_working_correctly.py
+++ b/tools/testing/pytest/tests/test_rules_are_working_correctly.py
@@ -10,5 +10,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-def test_local_fixture_has_correct_value(fixture42):
+def test_local_fixture_has_correct_value(fixture42: int) -> None:
     assert fixture42 == 42


### PR DESCRIPTION
Fix pylance warnings for reportMissingTypeArgument and reportUnusedVariable and some other warnings.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com