### PR TITLE
tooling: Add file based rule check tests

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -129,11 +129,7 @@ filegroup(
     name = "test_rst_files",
     srcs = glob([
         "_tooling/extensions/score_metamodel/tests/rst/**/*.rst",
-        "_tooling/extensions/score_plantuml.py",
-        "_tooling/extensions/score_draw_uml_funcs/**/*.py",
-        "_tooling/extensions/score_source_code_linker/**/*.py",
-        "_tooling/extensions/score_layout/**/*.py",
-        "_tooling/extensions/score_header_service/**/*.py",
+        "_tooling/extensions/**/*.py",
         "conf.py",
     ]),
     visibility = ["//visibility:public"],

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -128,7 +128,7 @@ py_library(
 filegroup(
     name = "test_rst_files",
     srcs = glob([
-        "_tooling/extensions/score_metamodel/tests/rst/*.rst",
+        "_tooling/extensions/score_metamodel/tests/rst/**/*.rst",
         "_tooling/extensions/score_plantuml.py",
         "_tooling/extensions/score_draw_uml_funcs/**/*.py",
         "_tooling/extensions/score_source_code_linker/**/*.py",
@@ -153,10 +153,10 @@ score_py_pytest(
     name = "score_metamodel_test",
     size = "small",
     srcs = glob(["_tooling/extensions/score_metamodel/tests/**/*.py"]),
-    visibility = ["//visibility:public"],
     data = [
         ":test_rst_files",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":score_metamodel",
     ],

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -125,6 +125,20 @@ py_library(
     ],
 )
 
+filegroup(
+    name = "test_rst_files",
+    srcs = glob([
+        "_tooling/extensions/score_metamodel/tests/rst/*.rst",
+        "_tooling/extensions/score_plantuml.py",
+        "_tooling/extensions/score_draw_uml_funcs/**/*.py",
+        "_tooling/extensions/score_source_code_linker/**/*.py",
+        "_tooling/extensions/score_layout/**/*.py",
+        "_tooling/extensions/score_header_service/**/*.py",
+        "conf.py",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
 # Dedicated metamodel target only for pytest.
 # It's required to define the imports for bazel pytest, so that python/pytest can
 # import "from score_metamodel" without issues.
@@ -140,7 +154,12 @@ score_py_pytest(
     size = "small",
     srcs = glob(["_tooling/extensions/score_metamodel/tests/**/*.py"]),
     visibility = ["//visibility:public"],
-    deps = [":score_metamodel"],
+    data = [
+        ":test_rst_files",
+    ],
+    deps = [
+        ":score_metamodel",
+    ],
 )
 
 # ───────────────────────── Source code linker ────────────────────────

--- a/docs/_tooling/docs.bzl
+++ b/docs/_tooling/docs.bzl
@@ -149,7 +149,7 @@ def _docs():
             "**/*.yaml",
             "**/*.json",
             "**/*.csv",
-        ], exclude = ["**/tests/rst/*.rst"]),
+        ], exclude = ["**/tests/rst/**/*.rst"]),
         config = ":conf.py",
         extra_opts = [
             "-W",

--- a/docs/_tooling/docs.bzl
+++ b/docs/_tooling/docs.bzl
@@ -149,7 +149,7 @@ def _docs():
             "**/*.yaml",
             "**/*.json",
             "**/*.csv",
-        ]),
+        ], exclude = ["**/tests/rst/*.rst"]),
         config = ":conf.py",
         extra_opts = [
             "-W",

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_description.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_description.rst
@@ -1,0 +1,28 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+.. Test xy
+#EXPECT: stkh_req__test__abcd.content (This should really work): contains a weak word: `really`.
+
+.. stkh_req:: This is a test
+   :id: stkh_req__test__abcd
+
+   This should really work
+
+#EXPECT-NOT: stkh_req__test__abce.title (This should work): contains a weak word
+
+.. stkh_req:: This is a test
+   :id: stkh_req__test__abce
+
+   This should work

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_format.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_format.rst
@@ -1,0 +1,33 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+#EXPECT: std_wp__test__test__abcd.id (std_wp__test__test__abcd): expected to consisting of this format: `<Req Type>__<Abbreviations>__<Architectural Element>`.
+
+.. std_wp:: This is a test
+   :id: std_wp__test__test__abcd
+
+#EXPECT-NOT: std_wp__test__abce.id (std_wp__test__abce): expected to consisting of this format: `<Req Type>__<Abbreviations>__<Architectural Element>`.
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abce
+
+#EXPECT: wp__test__test__abcd.id (wp__test__test__abcd): expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`.
+
+.. std_wp:: This is a test
+   :id: wp__test__test__abcd
+
+#EXPECT-NOT: wp__test__abce.id (wp__test__abce): expected to consisting of one of these 2 formats:`<Req Type>__<Abbreviations>` or `<Req Type>__<Abbreviations>__<Architectural Element>`.
+
+.. std_wp:: This is a test
+   :id: wp__test__abce

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_length.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_id_length.rst
@@ -1,0 +1,23 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+#EXPECT: std_wp__testabcdefghijklmnopqrstuvwxyz123__abcd.id (std_wp__testabcdefghijklmnopqrstuvwxyz123__abcd): exceeds the maximum allowed length of 45 characters (current length: 47).
+
+.. std_wp:: This is a test
+   :id: std_wp__testabcdefghijklmnopqrstuvwxyz123__abcd
+
+#EXPECT-NOT: std_wp__test__abce.id (std_wp__test__abce): exceeds the maximum allowed length of 45 characters
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abce

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_title.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/attributes/test_attributes_format_title.rst
@@ -1,0 +1,23 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+#EXPECT: feat_req__test__abcd.title (This must work): contains a stop word: `must`.
+
+.. feat_req:: This must work
+   :id: feat_req__test__abcd
+
+#EXPECT-NOT: feat_req__test__abce.title (This is a test): contains a stop word
+
+.. feat_req:: This is a test
+   :id: feat_req__test__abce

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/graph/test_metamodel_graph.rst
@@ -1,0 +1,40 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+.. feat_req:: Parent requirement
+   :id: feat_req__parent__abcd
+   :safety: QM
+   :status: valid
+
+#EXPECT: feat_req__child__abce: parent need `feat_req__parent__abcd` does not fulfill condition `{'and': ['safety != QM', 'status == valid']}`.
+
+.. feat_req:: Child requirement
+   :id: feat_req__child__abce
+   :safety: ASIL_B
+   :status: valid
+   :satisfies: feat_req__parent__abcd
+
+
+.. feat_req:: Parent requirement 2
+   :id: feat_req__parent2__abcd
+   :safety: ASIL_B
+   :status: valid
+
+#EXPECT-NOT: feat_req__child2__abce: parent need `feat_req__parent2__abcd` does not fulfill condition
+
+.. feat_req:: Child requirement 2
+   :id: feat_req__child2__abce
+   :safety: ASIL_B
+   :status: valid
+   :satisfies: feat_req__parent__abcd

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/options/test_options_extra_option.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/options/test_options_extra_option.rst
@@ -1,0 +1,24 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+#EXPECT: std_wp__test__abcd: has these extra options: `safety`.
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abcd
+   :safety: QM
+
+#EXPECT-NOT: std_wp__test__abce: has these extra options
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abce

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/options/test_options_options.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/options/test_options_options.rst
@@ -1,0 +1,24 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+#EXPECT: std_wp__test__abcd: is missing required option: `status`.
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abcd
+
+#EXPECT-NOT: std_wp__test__abce: is missing required option: `status`.
+
+.. std_wp:: This is a test
+   :id: std_wp__test__abce
+   :status: active

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/test_asil.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/test_asil.rst
@@ -1,4 +1,0 @@
-#EXPECT: std_wp__iso26262__abcd: is missing required option: `status`.
-
-.. std_wp:: This is a test
-   :id: std_wp__iso26262__abcd

--- a/docs/_tooling/extensions/score_metamodel/tests/rst/test_asil.rst
+++ b/docs/_tooling/extensions/score_metamodel/tests/rst/test_asil.rst
@@ -1,0 +1,4 @@
+#EXPECT: std_wp__iso26262__abcd: is missing required option: `status`.
+
+.. std_wp:: This is a test
+   :id: std_wp__iso26262__abcd

--- a/docs/_tooling/extensions/score_metamodel/tests/test_rules_file_based.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_rules_file_based.py
@@ -1,0 +1,135 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+import os
+from sphinx.testing.util import SphinxTestApp
+from sphinx_needs.data import SphinxNeedsData
+import pytest
+from pathlib import Path
+import shutil
+
+RST_DIR = Path(__file__).absolute().parent / "rst"
+DOCS_DIR = Path(__file__).absolute().parent.parent.parent.parent.parent
+TOOLING_DIR_NAME = "_tooling"
+
+RST_FILES = [str(f.name) for f in Path(RST_DIR).rglob("*.rst")]
+
+
+@pytest.fixture
+def sphinx_base_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    base_dir: Path = tmp_path_factory.mktemp("docs")
+    shutil.copy(DOCS_DIR / "conf.py", base_dir)
+    shutil.copytree(
+        DOCS_DIR / TOOLING_DIR_NAME,
+        base_dir / TOOLING_DIR_NAME,
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("*.rst"),
+    )
+    return base_dir
+
+
+@pytest.fixture
+def index_file() -> Callable[[Path], str]:
+    def _create_rst_file(rst_file: Path) -> str:
+        index_rst: str = f"""
+.. toctree::
+   {rst_file.stem}
+"""
+        return index_rst
+
+    return _create_rst_file
+
+
+@pytest.fixture
+def sphinx_app_setup(
+    sphinx_base_dir: Path, index_file: Callable[[Path], str]
+) -> Callable[[Path], SphinxTestApp]:
+    def _create_app(rst_file: Path) -> SphinxTestApp:
+        shutil.copy(rst_file, sphinx_base_dir)
+        index_context: str = index_file(rst_file)
+        (sphinx_base_dir / "index.rst").write_text(index_context)
+        app: SphinxTestApp = SphinxTestApp(
+            freshenv=True,
+            srcdir=sphinx_base_dir,
+            outdir=sphinx_base_dir / "out",
+            buildername="html",
+        )
+        return app
+
+    return _create_app
+
+
+@dataclass
+class InfoElement:
+    lineno: int = 0
+    expected: list[str] = field(default_factory=list)
+    not_expected: list[str] = field(default_factory=list)
+
+
+def extract_warning(line: str) -> str:
+    return line.split(": ", 1)[1].strip()
+
+
+def extract_test_data(rst_file: Path) -> list[InfoElement] | None:
+    with open(rst_file, "r") as f:
+        statements: list[InfoElement] = []
+        test_info: InfoElement | None = None
+        for no, line in enumerate(f, start=1):
+            if line.startswith(".. "):  # Beginning of new need
+                if test_info:
+                    test_info.lineno = no
+                    statements.append(test_info)
+                test_info = None
+            elif line.startswith("#EXPECT:") or line.startswith("#EXPECT-NOT:"):
+                if test_info is None:
+                    test_info = InfoElement()
+                target_list = (
+                    test_info.expected
+                    if line.startswith("#EXPECT:")
+                    else test_info.not_expected
+                )
+                target_list.append(extract_warning(line))
+        # Check last InfoElement
+        if test_info:
+            print("ERROR: Teststatement without according need found")
+        return statements
+    return None
+
+
+@pytest.mark.parametrize("rst_file", RST_FILES)
+def test_dummy_need(
+    rst_file: str, sphinx_app_setup: Callable[[Path], SphinxTestApp]
+) -> None:
+    assert (
+        test_data := extract_test_data(RST_DIR / rst_file)
+    ), "Unable to extract test data"
+    app: SphinxTestApp = sphinx_app_setup(RST_DIR / rst_file)
+    try:
+        os.chdir(app.srcdir) # Change working directory to the source directory
+        app.build()
+        warn_text: str = app.warning.getvalue()
+        for test in test_data:
+            for expected in test.expected:
+                assert (
+                    f"{Path(rst_file).name}:{test.lineno}: WARNING: {expected}" in warn_text
+                ), f"Expected warning: {[expected]} not found"
+            for not_expected in test.not_expected:
+                assert (
+                    f"{Path(rst_file).name}:{test.lineno}: WARNING: {not_expected}" not in warn_text
+                ), f"Unexpected warning: {[not_expected]} found"
+    except Exception as e:
+        assert False, f"Build failed: {e}"
+    finally:
+        app.cleanup()

--- a/docs/_tooling/extensions/score_metamodel/tests/test_rules_file_based.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_rules_file_based.py
@@ -11,24 +11,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+import os
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass, field
-import os
-from sphinx.testing.util import SphinxTestApp
-from sphinx_needs.data import SphinxNeedsData
-import pytest
 from pathlib import Path
-import shutil
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
 
 RST_DIR = Path(__file__).absolute().parent / "rst"
 DOCS_DIR = Path(__file__).absolute().parent.parent.parent.parent.parent
 TOOLING_DIR_NAME = "_tooling"
 
+### List of relative paths of all rst files in RST_DIR
 RST_FILES = [str(f.relative_to(RST_DIR)) for f in Path(RST_DIR).rglob("*.rst")]
 
 
 @pytest.fixture
 def sphinx_base_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    ### Create a temporary directory for Sphinx and copy all necessary files.
     base_dir: Path = tmp_path_factory.mktemp("docs")
     shutil.copy(DOCS_DIR / "conf.py", base_dir)
     shutil.copytree(
@@ -42,7 +44,10 @@ def sphinx_base_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 @pytest.fixture
 def index_file() -> Callable[[Path], str]:
+    ### Returns a function that creates an index.rst file.
     def _create_rst_file(rst_file: Path) -> str:
+        ### returns an index.rst file with a toctree
+        # that refers to the given rst file.
         index_rst: str = f"""
 .. toctree::
    {rst_file.stem}
@@ -56,7 +61,10 @@ def index_file() -> Callable[[Path], str]:
 def sphinx_app_setup(
     sphinx_base_dir: Path, index_file: Callable[[Path], str]
 ) -> Callable[[Path], SphinxTestApp]:
+    ### Returns a function that creates a SphinxTestApp instance.
     def _create_app(rst_file: Path) -> SphinxTestApp:
+        ### Create a SphinxTestApp instance.
+        # The source directory is set to the temporary directory.
         shutil.copy(rst_file, sphinx_base_dir)
         index_context: str = index_file(rst_file)
         (sphinx_base_dir / "index.rst").write_text(index_context)
@@ -72,20 +80,29 @@ def sphinx_app_setup(
 
 
 @dataclass
-class InfoElement:
+class WarningInfo:
+    #### Class to hold information about warnings
+    # The class contains the line number and the expected and not expected warnings.
     lineno: int = 0
     expected: list[str] = field(default_factory=list)
     not_expected: list[str] = field(default_factory=list)
 
 
 def extract_warning(line: str) -> str:
+    #### Extract the warning message from the line
+    # The line format is "#EXPECT: <warning message>"
+    # or "#EXPECT-NOT: <warning message>"
     return line.split(": ", 1)[1].strip()
 
 
-def extract_test_data(rst_file: Path) -> list[InfoElement] | None:
-    with open(rst_file, "r") as f:
-        statements: list[InfoElement] = []
-        test_info: InfoElement | None = None
+def extract_test_data(rst_file: Path) -> list[WarningInfo] | None:
+    ### Extract test data from the given rst file
+    # The function returns a list of WarningInfo objects
+    # containing the line number and the expected and not expected warnings.
+    # If no test data is found, it returns None.
+    with open(rst_file) as f:
+        statements: list[WarningInfo] = []
+        test_info: WarningInfo | None = None
         for no, line in enumerate(f, start=1):
             if line.startswith(".. "):  # Beginning of new need
                 if test_info:
@@ -94,7 +111,7 @@ def extract_test_data(rst_file: Path) -> list[InfoElement] | None:
                 test_info = None
             elif line.startswith("#EXPECT:") or line.startswith("#EXPECT-NOT:"):
                 if test_info is None:
-                    test_info = InfoElement()
+                    test_info = WarningInfo()
                 target_list = (
                     test_info.expected
                     if line.startswith("#EXPECT:")
@@ -105,33 +122,29 @@ def extract_test_data(rst_file: Path) -> list[InfoElement] | None:
         if test_info:
             print("ERROR: Teststatement without according need found")
         return statements
-    return None
 
 
 @pytest.mark.parametrize("rst_file", RST_FILES)
 def test_check_rules(
     rst_file: str, sphinx_app_setup: Callable[[Path], SphinxTestApp]
 ) -> None:
+    ### Test function to check rules in the given rst file
+    # The function uses the SphinxTestApp to build the documentation
+    # and checks for the expected/unexpected warnings.
     assert (
         test_data := extract_test_data(RST_DIR / rst_file)
     ), "Unable to extract test data"
     app: SphinxTestApp = sphinx_app_setup(RST_DIR / rst_file)
-    try:
-        os.chdir(app.srcdir)  # Change working directory to the source directory
-        app.build()
-        warn_text: str = app.warning.getvalue()
-        for test in test_data:
-            for expected in test.expected:
-                assert (
-                    f"{Path(rst_file).name}:{test.lineno}: WARNING: {expected}"
-                    in warn_text
-                ), f"Expected warning: {[expected]} not found"
-            for not_expected in test.not_expected:
-                assert (
-                    f"{Path(rst_file).name}:{test.lineno}: WARNING: {not_expected}"
-                    not in warn_text
-                ), f"Unexpected warning: {[not_expected]} found"
-    except Exception as e:
-        assert False, f"Build failed: {e}"
-    finally:
-        app.cleanup()
+    os.chdir(app.srcdir)  # Change working directory to the source directory
+    app.build()
+    warn_text: str = app.warning.getvalue()
+    for test in test_data:
+        for expected in test.expected:
+            assert (
+                f"{Path(rst_file).name}:{test.lineno}: WARNING: {expected}" in warn_text
+            ), f"Expected warning: {[expected]} not found"
+        for not_expected in test.not_expected:
+            assert (
+                f"{Path(rst_file).name}:{test.lineno}: WARNING: {not_expected}"
+                not in warn_text
+            ), f"Unexpected warning: {[not_expected]} found"


### PR DESCRIPTION
Introduce new testing method with rst files as input.

Fixes: https://github.com/eclipse-score/score/issues/736