### PR TITLE
tooling: Reduce most of Pylance remaining new types of warnings

### DIFF
--- a/docs/_tooling/extensions/score_draw_uml_funcs/helpers.py
+++ b/docs/_tooling/extensions/score_draw_uml_funcs/helpers.py
@@ -276,8 +276,8 @@ def get_impl_comp_from_real_iface(
     real_iface: str, all_needs: dict[str, dict[str, str]]
 ) -> list[str]:
     """Get implementing component of the interface"""
-    implcomp: list[str] = all_needs[real_iface].get("implements_back", [])
-
+    value = all_needs[real_iface].get("implements_back", [])
+    implcomp = value if isinstance(value, list) else []
     if not implcomp:
         logger.info(
             f"{all_needs[real_iface]['id']}: Implementing Component not specified!"

--- a/docs/_tooling/extensions/score_header_service/header_service.py
+++ b/docs/_tooling/extensions/score_header_service/header_service.py
@@ -16,7 +16,7 @@ import random
 import re
 import subprocess
 from collections import defaultdict
-from typing import Any, ClassVar
+from typing import Any
 
 from github import (
     Auth,
@@ -72,7 +72,7 @@ def generate_hash() -> str:
 
 
 class HeaderService(BaseService):
-    options = {}
+    options = []
 
     def __init__(
         self,
@@ -141,7 +141,10 @@ def _extract_merge_commit_data(location: str) -> dict[str, str | list[str]]:
         "hash": "N/A",
     }
 
-    git_cmd = f'git log --pretty="format:%H%n%an, %ae%n%b" --max-count=1 --merges --first-parent -p "{location}'
+    git_cmd = (
+        f'git log --pretty="format:%H%n%an, %ae%n%b" --max-count=1 --merges '
+        f'--first-parent -p "{location}"'
+    )
 
     result = subprocess.run([git_cmd], shell=True, capture_output=True)
 

--- a/docs/_tooling/extensions/score_header_service/test/test_header_service.py
+++ b/docs/_tooling/extensions/score_header_service/test/test_header_service.py
@@ -16,6 +16,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 import score_header_service.header_service as hs
+from sphinx.util.docutils import SphinxDirective
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -125,7 +126,8 @@ def test_debug(mock_app: MagicMock, mock_request_from_directive: MagicMock):
     debug_data = [{"key": "value"}]
     mock_request_from_directive.return_value = debug_data
     header_service = hs.HeaderService(mock_app, "dummy-service", None)
-    assert header_service.debug(None) == debug_data
+    mock_directive = MagicMock(spec=SphinxDirective)  # ✅ This matches expected type
+    assert header_service.debug(mock_directive) == debug_data
 
 
 @patch("score_header_service.header_service.subprocess.run")
@@ -156,7 +158,8 @@ Reviewed: {reviewer3} ( {reviewer3@mail.com} ) on {2024-12-3}"""
     }
     run_mock.assert_called_once_with(
         [
-            'git log --pretty="format:%H%n%an, %ae%n%b" --max-count=1 --merges --first-parent -p "/req/feature1'
+            'git log --pretty="format:%H%n%an, %ae%n%b" '
+            '--max-count=1 --merges --first-parent -p "/req/feature1"'
         ],
         shell=True,
         capture_output=True,

--- a/docs/_tooling/extensions/score_layout/sphinx_options.py
+++ b/docs/_tooling/extensions/score_layout/sphinx_options.py
@@ -10,7 +10,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-needs_layouts = {
+from typing import Literal, TypedDict
+
+LayoutDict = dict[str, list[str]]
+
+
+class SingleLayout(TypedDict):
+    grid: Literal["complex", "content"]
+    layout: dict[str, list[str]]
+
+
+needs_layouts: dict[str, SingleLayout] = {
     "score": {
         "grid": "complex",
         "layout": {

--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -102,9 +102,6 @@ def load_metamodel_data():
         data = yaml.load(f)
 
     # Access the custom validation block
-    prohibited_words_dict = data.get("needs_types_base_options", {}).get(
-        "prohibited_words", {}
-    )
 
     types_dict = data.get("needs_types", {})
     links_dict = data.get("needs_extra_links", {})
@@ -115,8 +112,8 @@ def load_metamodel_data():
 
     # Get the list of stop-words and weak-words
     # Get the stop_words and weak_words as separate lists
-    stop_words_list = prohibited_words_dict.get("title", [])
-    weak_words_list = prohibited_words_dict.get("content", [])
+    stop_words_list = global_base_options.get("prohibited_words", {}).get("title", [])
+    weak_words_list = global_base_options.get("prohibited_words", {}).get("content", [])
 
     # Default options by sphinx, sphinx-needs or anything else we need to account for
     default_options_list = default_options()
@@ -233,7 +230,7 @@ def default_options() -> list[str]:
     ]
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> dict[str, str | bool]:
     app.config.needs_id_required = True
     app.config.needs_id_regex = "^[A-Za-z0-9_-]{6,}"
 

--- a/docs/_tooling/extensions/score_metamodel/tests/test_attributes_format.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_attributes_format.py
@@ -13,7 +13,6 @@
 from unittest.mock import Mock
 
 from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType
 
 from docs._tooling.extensions.score_metamodel.checks.attributes_format import (
     check_description,
@@ -21,9 +20,7 @@ from docs._tooling.extensions.score_metamodel.checks.attributes_format import (
     check_id_length,
     check_title,
 )
-from docs._tooling.extensions.score_metamodel.tests import (
-    fake_check_logger,
-)
+from docs._tooling.extensions.score_metamodel.tests import fake_check_logger, need
 
 
 class TestId:
@@ -35,14 +32,14 @@ class TestId:
         Test check_id_length function with a positive case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="gd_req__attribute_satisfies",
         )
 
         logger = fake_check_logger()
         app = Mock(spec=Sphinx)
 
-        check_id_format(app, need, logger)
+        check_id_format(app, need_1, logger)
         assert not logger.has_warnings
 
     def test_check_id_format_two_mendatory_substrings_parts_negative(self):
@@ -50,14 +47,14 @@ class TestId:
         Test check_id_length function with a negative case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="gd_req_attribute_satisfies",
         )
 
         logger = fake_check_logger()
         app = Mock(spec=Sphinx)
 
-        check_id_format(app, need, logger)
+        check_id_format(app, need_1, logger)
 
         logger.assert_warning(
             "expected to consisting of one of these 2 formats:"
@@ -71,14 +68,14 @@ class TestId:
         Test check_id_length function with a negative case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="feat_req__1",
         )
 
         logger = fake_check_logger()
         app = Mock(spec=Sphinx)
 
-        check_id_format(app, need, logger)
+        check_id_format(app, need_1, logger)
 
         logger.assert_warning(
             "expected to consisting of this format: "
@@ -91,14 +88,14 @@ class TestId:
         Test check_id_length function with a positive case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="std_req__iso26262__rq_8_6432",
         )
 
         logger = fake_check_logger()
         app = Mock(spec=Sphinx)
 
-        check_id_length(app, need, logger)
+        check_id_length(app, need_1, logger)
         assert not logger.has_warnings
 
     def test_check_id_length_negative(self):
@@ -106,22 +103,22 @@ class TestId:
         Test check_id_length function with a negative case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="std_req__iso26262__rq_8_6432_0000000000000000000000",
         )
 
         logger = fake_check_logger()
         app = Mock(spec=Sphinx)
 
-        check_id_length(app, need, logger)
+        check_id_length(app, need_1, logger)
         logger.assert_warning(
             f"exceeds the maximum allowed length of 45 characters "
-            f"(current length: {len(need["id"])}).",
+            f"(current length: {len(need_1["id"])}).",
             expect_location=False,
         )
 
     def test_check_title_positive(self):
-        need = NeedsInfoType(
+        need_1 = need(
             id="std_req__iso26262__rq_8_6432",
             title="std_req  iso26262",
             type="feat_req",
@@ -132,7 +129,7 @@ class TestId:
         app.config = Mock()
         app.config.stop_words = self.STOP_WORDS
 
-        check_title(app, need, logger)
+        check_title(app, need_1, logger)
         assert not logger.has_warnings
 
     def test_check_title_negative(self):
@@ -140,7 +137,7 @@ class TestId:
         Test check_title function with a negative case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="gd_req__doc_shall_approver",
             title="gd_req doc shall approver",
             type="feat_req",
@@ -151,7 +148,7 @@ class TestId:
         app.config = Mock()
         app.config.stop_words = self.STOP_WORDS
 
-        check_title(app, need, logger)
+        check_title(app, need_1, logger)
         logger.assert_warning(
             (
                 "contains a stop word: `shall`. The title is meant to provide a short "
@@ -162,7 +159,7 @@ class TestId:
         )
 
     def test_check_description_positive(self):
-        need = NeedsInfoType(
+        need_1 = need(
             id="std_req__iso26262__rq_8_6432",
             content="This is the description of the requirement",
             type="feat_req",
@@ -173,7 +170,7 @@ class TestId:
         app.config = Mock()
         app.config.weak_words = self.WEAK_WORDS
 
-        check_description(app, need, logger)
+        check_description(app, need_1, logger)
         assert not logger.has_warnings
 
     def test_check_description_negative(self):
@@ -181,7 +178,7 @@ class TestId:
         Test check_description function with a negative case.
         """
 
-        need = NeedsInfoType(
+        need_1 = need(
             id="gd_req__doc_shall_approver",
             content="This is just the description of the requirement",
             type="feat_req",
@@ -192,7 +189,7 @@ class TestId:
         app.config = Mock()
         app.config.weak_words = self.WEAK_WORDS
 
-        check_description(app, need, logger)
+        check_description(app, need_1, logger)
         logger.assert_warning(
             "contains a weak word: `just`. Please revise the description.",
             expect_location=False,

--- a/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
+++ b/docs/_tooling/extensions/score_metamodel/tests/test_standards.py
@@ -14,11 +14,9 @@
 # from unittest.mock import Mock
 
 # from sphinx.application import Sphinx
-from sphinx_needs.data import NeedsInfoType
 
 from docs._tooling.extensions.score_metamodel.checks import standards
-
-# from docs._tooling.extensions.score_metamodel.tests import fake_check_logger
+from docs._tooling.extensions.score_metamodel.tests import need  # ,fake_check_logger
 
 
 class TestStandards:
@@ -35,7 +33,7 @@ class TestStandards:
     #        have complies tag via the same tag.
     #        """
     #
-    #        need_1 = NeedsInfoType(
+    #        need_1 = need(
     #            target_id="Traceability of safety requirements",
     #            id="std_req__iso26262__rq-8-6432",
     #            type="std_req",
@@ -45,7 +43,7 @@ class TestStandards:
     #            lineno=None,
     #        )
     #
-    #        need_2 = NeedsInfoType(
+    #        need_2 = need(
     #            target_id="Requirements attribute satisfies",
     #            id="gd_req__attribute_satisfies",
     #            tags="attribute",
@@ -81,7 +79,7 @@ class TestStandards:
     #     have complies tag via the same tag.
     #     """
 
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Traceability of safety requirements",
     #         id="std_req__iso26262__rq-8-6432",
     #         type="std_req",
@@ -91,7 +89,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="Requirements attribute satisfies",
     #         id="gd_req__attribute_satisfies",
     #         type="gd_req",
@@ -123,17 +121,17 @@ class TestStandards:
     #         expect_location=False,
     #     )
 
-    # def test_check_all_standard_workproducts_linked_item_via_the_compliance_wp_positive(
+    # def test_all_workproduct_linked_via_compliance_wp(
     #     self,
     # ):
     #     """
     #     Test if check all_standard_workproducts_linked_item_via_the_compliance_wp
-    #     function will give a False value (check is valid) when giving a standar
+    #     function will give a False value (check is valid) when giving a standard
     #     workproduct which is linked to at least one of the list of items that have
     #     complies tag via the same tag.
     #     """
 
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Organization-specific rules and processes for safety",
     #         id="std_wp__iso26262__wp-2-551",
     #         type="std_wp",
@@ -142,7 +140,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="wp__policies",
     #         id="wp__policies",
     #         type="workproduct",
@@ -177,7 +175,7 @@ class TestStandards:
     #     have complies tag via the same tag.
     #     """
 
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Organization-specific rules and processes for safety",
     #         id="std_wp__iso26262__wp-2-551",
     #         type="std_wp",
@@ -186,7 +184,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="wp__policies",
     #         id="wp__policies",
     #         type="workproduct",
@@ -221,7 +219,7 @@ class TestStandards:
     #     exactly to one workflow least from the list of all workflows via
     #     output option.
     #     """
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Module Safety Plan",
     #         type="workproduct",
     #         id="wp__module_safety_plan",
@@ -236,7 +234,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
     #         id="wf__cr_mt_safety_plan",
@@ -262,7 +260,7 @@ class TestStandards:
     #     standards.check_workproduct_uniqueness_over_workflows(app, needs, logger)
     #     logger.assert_no_warnings()
 
-    # def test_check_workproduct_uniqueness_over_workflows_negative_wprkproduct_not_listed_in_any_workflow(
+    # test_workproduct_not_in_any_workflow(
     #     self,
     # ):
     #     """
@@ -272,7 +270,7 @@ class TestStandards:
     #     output option.
     #     """
 
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Module Safety Plan",
     #         type="workproduct",
     #         id="wp__module_safety_plan",
@@ -288,7 +286,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
     #         id="wf__cr_mt_safety_plan",
@@ -318,7 +316,7 @@ class TestStandards:
     #         expect_location=False,
     #     )
 
-    # def test_check_workproduct_uniqueness_over_workflows_negative_wprkproduct_listed_in_multiple_workflows(
+    # def test_workproduct_not_in_different_workflows(
     #     self,
     # ):
     #     """
@@ -328,7 +326,7 @@ class TestStandards:
     #     via output option.
     #     """
 
-    #     need_1 = NeedsInfoType(
+    #     need_1 = need(
     #         target_id="Module Safety Plan",
     #         type="workproduct",
     #         id="wp__module_safety_plan",
@@ -343,7 +341,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_2 = NeedsInfoType(
+    #     need_2 = need(
     #         target_id="Create/Maintain Safety Plan",
     #         type="workflow",
     #         id="wf__cr_mt_safety_plan",
@@ -361,7 +359,7 @@ class TestStandards:
     #         lineno=None,
     #     )
 
-    #     need_3 = NeedsInfoType(
+    #     need_3 = need(
     #         target_id="Review/Approve Contribution request",
     #         type="workflow",
     #         id="wf__rv_ap_ContrRequest",
@@ -406,7 +404,7 @@ class TestStandards:
         """
         needs = {}
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Traceability of safety requirements",
             id="std_req__iso26262__rq-8-6432",
             type="std_req",
@@ -416,7 +414,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Traceability",
             id="std_req__iso26262__rq-8-0000",
             type="std_req",
@@ -426,7 +424,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_3 = NeedsInfoType(
+        need_3 = need(
             target_id="Requirements attribute satisfies",
             id="gd_req__attribute_satisfies",
             security="NO",
@@ -466,7 +464,7 @@ class TestStandards:
         a special case will give the correct value.
         """
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Organization-specific rules and processes for safety",
             id="std_wp__iso26262__wp-2-551",
             type="std_wp",
@@ -475,7 +473,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="specific rules for processes",
             id="std_wp__iso26262__wp-2-0000",
             type="std_wp",
@@ -484,7 +482,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_3 = NeedsInfoType(
+        need_3 = need(
             target_id="wp__policies",
             id="wp__policies",
             status="draft",
@@ -520,7 +518,7 @@ class TestStandards:
         a special case will give the correct value.
         """
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Module Safety Plan",
             type="workproduct",
             id="wp__module_safety_plan",
@@ -535,7 +533,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
             id="wf__cr_mt_safety_plan",
@@ -553,7 +551,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_3 = NeedsInfoType(
+        need_3 = need(
             target_id="Module Safety Plan",
             type="workproduct",
             id="wp__module",
@@ -568,7 +566,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_4 = NeedsInfoType(
+        need_4 = need(
             target_id="Module Safety Plan",
             type="workproduct",
             id="wp__module_safety",
@@ -582,7 +580,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_5 = NeedsInfoType(
+        need_5 = need(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
             id="WF__CR_MT_SAFETY",
@@ -600,7 +598,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_6 = NeedsInfoType(
+        need_6 = need(
             target_id="Review/Approve Contribution request",
             type="workflow",
             id="wf__rv_ap_ContrRequest",
@@ -642,7 +640,7 @@ class TestStandards:
         """
         Test if get_standards_needs works as expected with a positive and negative test.
         """
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Traceability of safety requirements",
             id="std_req__iso26262__rq-8-6432",
             type="std_req",
@@ -652,7 +650,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Traceability of requirements",
             id="wp__11111111",
             reqtype="Functional",
@@ -673,7 +671,7 @@ class TestStandards:
         Test if get_standards_workproducts works as expected with a
         positive and negative test.
         """
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Organization-specific rules and processes for safety",
             id="std_wp__iso26262__wp-2-551",
             type="std_wp",
@@ -682,7 +680,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Traceability of requirements",
             id="wp__11111111",
             reqtype="Functional",
@@ -704,7 +702,7 @@ class TestStandards:
         and negative test.
         """
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Requirements attribute satisfies",
             id="gd_req__attribute_satisfies",
             type="workproduct",
@@ -722,7 +720,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Requirements attribute satisfies",
             id="gd_req__attribute_satisfies",
             type="gd_req",
@@ -752,7 +750,7 @@ class TestStandards:
         negative test.
         """
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Requirements attribute satisfies_1",
             id="gd_req__attribute_satisfies",
             type="gd_req",
@@ -768,7 +766,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Requirements attribute satisfies",
             id="wp__attribute_satisfies_2",
             type="workproduct",
@@ -794,7 +792,7 @@ class TestStandards:
         """
         Test if get_workflows works as expected with a positive and negative test.
         """
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Module Safety Plan",
             type="workproduct",
             id="wp__module_safety_plan",
@@ -809,7 +807,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
             id="wf__cr_mt_safety_plan",
@@ -838,7 +836,7 @@ class TestStandards:
         Test if get_workproducts works as expected with a positive and negative test.
         """
 
-        need_1 = NeedsInfoType(
+        need_1 = need(
             target_id="Module Safety Plan",
             type="workproduct",
             id="wp__module_safety_plan",
@@ -853,7 +851,7 @@ class TestStandards:
             lineno=None,
         )
 
-        need_2 = NeedsInfoType(
+        need_2 = need(
             target_id="Create/Maintain Safety Plan",
             type="workflow",
             id="wf__cstd_req__mt_safety_plan",

--- a/docs/_tooling/extensions/score_source_code_linker/parse_source_files.py
+++ b/docs/_tooling/extensions/score_source_code_linker/parse_source_files.py
@@ -94,7 +94,7 @@ def extract_requirements(
     if git_hash_func is None:
         git_hash_func = get_git_hash
 
-    requirement_mapping = collections.defaultdict(list)
+    requirement_mapping: dict[str, list[str]] = collections.defaultdict(list)
     with open(source_file) as f:
         for line_number, line in enumerate(f):
             line_number = line_number + 1
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("inputs", nargs="*")
 
     args, _ = parser.parse_known_args()
-    requirement_mappings = collections.defaultdict(list)
+    requirement_mappings: dict[str, list[str]] = collections.defaultdict(list)
     for input in args.inputs:
         with open(input) as f:
             for source_file in f:


### PR DESCRIPTION
Fix most of the Pylance warnings for reportUnknownVariableType except those related to the Metamodel complex data type.

I also divided some complex functions into small ones to reduce the complexity.

As well I didn't fix the new warnings coming from the new way of testing from the main as they are out of context of this PR.

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

I just skipped 26 warnings related to loading the metamodel, as the type is very complex. Plus, there is one extra sphinx_autobuild function import warning that has an unknown type.
 
Maybe someone from the reviewers can give an opinion on this complex data, or we could ignore it for now.

Related to: #836 