### PR TITLE
tooling: Log errors related to new checks as Infos

### DIFF
--- a/docs/_tooling/extensions/score_metamodel/__init__.py
+++ b/docs/_tooling/extensions/score_metamodel/__init__.py
@@ -84,6 +84,12 @@ def _run_checks(app: Sphinx, exception: Exception | None) -> None:
         log.warning("Some needs have issues. See the log for more information.")
         # TODO: exit code
 
+    if log.has_infos:
+        log.info(
+            "Some needs have issues related to the new checks. See the log for more information."
+        )
+        # TODO: exit code
+
 
 def load_metamodel_data():
     """


### PR DESCRIPTION
Implement a new function that logs errors related to new checks as Info's and not normal warnings, with a message requesting to fix them before the new project version release.

A request for all team members to understand the new implementation of the log function and use it correctly whenever you introduce new checks in the project  

Also-by: Aymen Soussi aymen.soussi@expleogroup.com

close: #735