### PR TITLE
chore: update score_docs_as_code to 0.2.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,4 +90,4 @@ bazel_dep(name = "score_cr_checker", version = "0.2.2")
 bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
 # Checker rule for CopyRight checks/fixs
 
-bazel_dep(name = "score_docs_as_code", version = "0.1.0")
+bazel_dep(name = "score_docs_as_code", version = "0.2.0")


### PR DESCRIPTION
## What's Changed
* quick fix for randomly failing build by @AlexanderLanin in https://github.com/eclipse-score/docs-as-code/pull/13
* fix command line argument for live_preview by @AlexanderLanin in https://github.com/eclipse-score/docs-as-code/pull/15
* rename process-docs to examples/simple by @AlexanderLanin in https://github.com/eclipse-score/docs-as-code/pull/17

**Full Changelog**: https://github.com/eclipse-score/docs-as-code/compare/release-0.1.1...release-0.2.0