### PR TITLE
rename cft to ft

### DIFF
--- a/docs/contribute/contribution_request/index.rst
+++ b/docs/contribute/contribution_request/index.rst
@@ -78,7 +78,7 @@ Join Us in Building S-CORE
   Submit a contribution pitch for a specific feature request if you have a solution you'd like to share.
 
 - **Looking to Improve What's Already There?**
-  Contribute enhancements to existing implementations or get involved with one of our cross-functional teams (CFTs).
+  Contribute enhancements to existing implementations or get involved with one of our Feature Teams (FTs).
 
 We're excited to have you on board. Together, we can shape S-CORE into a platform that's not only innovative but also a joy to be a part of.
 

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -49,7 +49,7 @@ How is S-CORE organized
 
 Eclipse S-CORE is an open source project, so everyone is welcome to contribute. Since we are organized within the Eclipse Foundation, you must have an Eclipse Foundation account to participate - please see :ref:`contribution_attribution` for details.
 
-The project is structured into various :ref:`technical committees <pmp_pm_technical_committees>`, which include communities focused on specific domains and cross-functional teams responsible for defined work areas. Their meetings are public; feel free to join or review the minutes via our `GitHub Discussions <https://github.com/orgs/eclipse-score/discussions>`_.
+The project is structured into various :ref:`technical committees <pmp_pm_technical_committees>`, that include communities which focus on cross-cutting topics and feature teams responsible for the implementation of specific functionalities. Their meetings are public; feel free to join or review the minutes via our `GitHub Discussions <https://github.com/orgs/eclipse-score/discussions>`_.
 
 Additionally, two :ref:`steering committees <pmp_pm_steering_committees>`, the Technical Lead Circle and the Project Lead Circle, oversee the overall steering and planning of S-CORE.
 

--- a/docs/platform_management_plan/problem_resolution.rst
+++ b/docs/platform_management_plan/problem_resolution.rst
@@ -120,7 +120,7 @@ ISSUE using the Problem Template :ref:`prm_templates`.
 
 :need:`[[title]] <gd_req__problem__attr_stakeholder>` is defined in the description part of the
 ISSUE using the Problem Template :ref:`prm_templates`. For S-CORE stakeholder use pre-defined labels
-for Communities or Cross Functional Teams (Feature Owner) (under discussion, compare
+for Communities or Feature Teams (Feature Owner) (under discussion, compare
 https://github.com/eclipse-score/score/issues/870)
 
 :need:`[[title]] <gd_req__problem__attr_classification>` is defined in the description part of the

--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -84,17 +84,15 @@ Technical committees
   in order to achieve milestones on time. All important architectural decisions
   should be reported to the project as *Feature Request* to get the final approvement from the *Technical lead circle*.
 
-* **Cross functional teams**
+* **Feature Teams**
 
-  *Cross functional teams* are responsible for some piece
-  of work from the beginning (e.g. definition of the architecture) till the end
-  (e.g. integration tests) and are usually assigned to the *S-CORE* main integration project or to one particular software module. *Cross-functional teams* work independently from each other on *GitHub Issues* in the assigned software module. *Cross-functional teams* consist of the contributors, who can specify requirements, define architecture, develop source code and implement tests afterwards. *Project Leads* and *Committers* are also *Contributors* and effectively work on processing of *GitHub Issues*.
+  *Feature Teams* have end-to-end responsibility for specific functionalities. This includes all aspects beginning with the architecture definition to the integration test. They are usually assigned to the *S-CORE* main integration project or to one particular software module. *Feature Teams* work independently of each other on *GitHub Issues* in the assigned software module. *Feature Teams* consist of the contributors, who can specify requirements, define architecture, develop source code and implement tests afterwards. *Project Leads* and *Committers* are also *Contributors* and effectively work on processing of *GitHub Issues*.
 
-  *Cross-functional team* usually consists of the following roles: Project Lead, Safety Manager, Quality Manager, Security Manager, Committers and Contributors. Every *cross-functional* team has at least one committer who can approve and merge the Pull Requests of the Contributors.
+  *Feature Team* usually consists of the following roles: Project Lead, Safety Manager, Quality Manager, Security Manager, Committers and Contributors. Every *Feature Team* has at least one committer who can approve and merge the Pull Requests of the Contributors.
 
-  In case *Cross-functional team* needs to request a new repository, this can be done be extending the `otterdog configuration file <https://github.com/eclipse-score/.eclipsefdn/blob/main/otterdog/eclipse-score.jsonnet>`_ and creating a new PR, that should be approved by the *Eclipse Project Security Team*.
+  In case a *Feature Team* needs to request a new repository, this can be done be extending the `otterdog configuration file <https://github.com/eclipse-score/.eclipsefdn/blob/main/otterdog/eclipse-score.jsonnet>`_ and creating a new PR, that has to be approved by the *Eclipse Project Security Team*.
 
-  The *GitHub Discussions* for cross-functional teams can be found in the `Cross-functional teams section <https://github.com/orgs/eclipse-score/discussions>`_ of the main *S-CORE* project.
+  The *GitHub Discussions* for feature teams can be found in the `Feature Teams section <https://github.com/orgs/eclipse-score/discussions>`_ of the main *S-CORE* project.
 
 Meeting Structure
 -----------------
@@ -364,7 +362,7 @@ and gets assigned to one of the *Communities* for refinement. The state of the s
     :alt: Planning workflow
     :align: center
 
-The members of the *Responsible Community* define or refine feature, process or tool requirements. They may also create feature architecture and high level component requirements for every involved software component. Depending on the feature scope, one of the cross-functional team can be requested to make a POC in the `incubation repository <https://eclipse-score.github.io/score/features/integration/index.html#incubation-repositories>`_. Finally, *Responsible Community* does the break down of the corresponding *saga* to the tickets that can be assigned to the individual software modules or *communities*.
+The members of the *Responsible Community* define or refine feature, process or tool requirements. They may also create feature architecture and high level component requirements for every involved software component. Depending on the feature scope, one of the feature team can be requested to make a POC in the `incubation repository <https://eclipse-score.github.io/score/features/integration/index.html#incubation-repositories>`_. Finally, *Responsible Community* does the break down of the corresponding *saga* to the tickets that can be assigned to the individual software modules or *communities*.
 As most of the software modules will have their own separate repository,
 then the detailed tracking of their work will also happen inside of that repository.
 However, the corresponding saga of the S-CORE repository will still have a sub-issue of type epic,

--- a/docs/process/process_areas/release_management/guidance/release_guideline.rst
+++ b/docs/process/process_areas/release_management/guidance/release_guideline.rst
@@ -38,7 +38,7 @@ Software Module Release
 
 3. **Development and Testing**:
 
-   * According process, cross functional teams implement and test.
+   * According process, feature teams implement and test.
    * Check the :need:`wp__verification__module_ver_report` to ensure that all tests pass before proceeding to the release.
    * In case of failed test, evaluate and possibly justify their failure.
 

--- a/docs/process/roles/index.rst
+++ b/docs/process/roles/index.rst
@@ -119,7 +119,7 @@ S-CORE development roles
    units. In this way the testing community takes a supportive role for unit testing
 
 
-S-CORE cross functional teams
+S-CORE feature teams
 -----------------------------
 
 .. role:: Platform Team

--- a/docs/score_releases/index.rst
+++ b/docs/score_releases/index.rst
@@ -53,28 +53,28 @@ SW Module List
      - Q4
      - _
      - `inc_mw_com <https://github.com/eclipse-score/inc_mw_com>`_
-     - `Communication CTF <https://github.com/orgs/eclipse-score/discussions/categories/communication-cft>`_
+     - `Communication CTF <https://github.com/orgs/eclipse-score/discussions/categories/communication-ft>`_
    * - Fixed Execution Order Framework (incl. Orchestrator)
      - Holger Grandy, Gerd Schäfer, Nico Hartmann, Sven Kappel, Thilo Schmitt
      - v0.5
      - Q4
      - _
      - `inc_feo <https://github.com/eclipse-score/inc_feo>`_
-     - `FEO CTF <https://github.com/orgs/eclipse-score/discussions/categories/feo-cft>`_
+     - `FEO CTF <https://github.com/orgs/eclipse-score/discussions/categories/feo-ft>`_
    * - Logging
      - Holger Grandy, Gerd Schäfer, Nico Hartmann
      - v0.5
      - Q4
      - _
      - `inc_mw_log <https://github.com/eclipse-score/inc_mw_log>`_
-     - `Logging CTF <https://github.com/orgs/eclipse-score/discussions/categories/logging-cft>`_
+     - `Logging CTF <https://github.com/orgs/eclipse-score/discussions/categories/logging-ft>`_
    * - Persistency
      - Gerd Schäfer, Nico Hartmann, Sven Kappel
      - v0.5
      - Q4
      - _
      - `inc_mw_per <https://github.com/eclipse-score/inc_mw_per>`_
-     - `Persistency CTF <https://github.com/orgs/eclipse-score/discussions/categories/persistency-cft>`_
+     - `Persistency CTF <https://github.com/orgs/eclipse-score/discussions/categories/persistency-ft>`_
    * - Integration Testing Framework
      - Holger Grandy
      - v0.5


### PR DESCRIPTION
Rename cross-functional teams to feature teams and update the links.