### PR TITLE
Preparing for first pre-release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
         run: sudo apt update && sudo apt install -y graphviz
       - name: Build documentation
         run: |
-          bazel build //docs:github-pages && cp bazel-bin/docs/github-pages.tar .
+          bazel build //docs:github_pages && cp bazel-bin/docs/github_pages.tar .
         # ------------------------------------------------------------------------------
         # Generate a unique artifact name to ensure proper tracking in all scenarios
         # ------------------------------------------------------------------------------

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,4 +90,4 @@ bazel_dep(name = "score_cr_checker", version = "0.2.2")
 bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
 # Checker rule for CopyRight checks/fixs
 
-bazel_dep(name = "score_docs_as_code", version = "0.2.1")
+bazel_dep(name = "score_docs_as_code", version = "0.2.4")

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -31,28 +31,3 @@ docs(
     source_dir = "docs",
     source_files_to_scan_for_needs_links = [],
 )
-
-# Used inside //docs.bzl to enable access to the assets (css files etc.)
-filegroup(
-    name = "assets",
-    srcs = glob([
-        "_assets/**",
-    ]),
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "html",
-    srcs = [":docs"],
-)
-
-pkg_files(
-    name = "html_files",
-    srcs = [":html"],
-    renames = {"html": ""},
-)
-
-pkg_tar(
-    name = "github-pages",
-    srcs = [":html_files"],
-)


### PR DESCRIPTION
Changing docs-as-code to new version.
In conjunction with that, changing the GH-Workflow to reflect new naming.
Removing duplicate targets that have been moved to 'docs-as-code'