### PR TITLE
Fix documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,4 +112,4 @@ jobs:
         id: pages-deployment
         uses: ./.github/actions/deploy-versioned-pages
         with:
-          source_folder: extracted_docs
+          source_folder: extracted_docs/html


### PR DESCRIPTION
This should fix the need to add '/html' to the end of URL's in order to get to the Documentation correctly.