### PR TITLE
infra: Autoclose stale PRs

### DIFF
--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -40,16 +40,13 @@ jobs:
           days-before-issue-close: -1 # Override days-before-close for issues only
 
           # Handle PRs
-          # Mark as stale after 30 days of inactivity and then for stale PRs close immediately
+          # Mark as stale after 30 days of inactivity and then for stale PRs close after 10 days
           days-before-pr-stale: 30 # Override days-before-stale for PRs only
-          days-before-pr-close: 0 # Override days-before-close for PRs only
+          days-before-pr-close: 10 # Override days-before-close for PRs only
           close-pr-label: autoclose # Label the PR as autoclosed
 
           # Add comment to the PR when it is closed
           close-pr-message: "Auto-closing: no activity for 30 days. If this is still relevant, reopen or create a fresh PR."
-
-          # Drafts dont create docs so leave them alone
-          exempt-draft-pr: true
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -43,7 +43,12 @@ jobs:
           # Mark as stale after 30 days of inactivity and then for stale PRs close after 10 days
           days-before-pr-stale: 30 # Override days-before-stale for PRs only
           days-before-pr-close: 10 # Override days-before-close for PRs only
-          close-pr-label: autoclose # Label the PR as autoclosed
+
+          # Add message to the PR when it is stale
+          stale-pr-message: >
+            This PR is stale because it has been open for 30 days with no activity. It will be closed in 10 days if no further activity occurs. #magic___^_^___line
+          # Label the PR as autoclosed
+          close-pr-label: autoclose
 
           # Add comment to the PR when it is closed
           close-pr-message: "Auto-closing: no activity for 30 days. If this is still relevant, reopen or create a fresh PR."

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -24,7 +24,33 @@ jobs:
     permissions:
       pages: write
       contents: write
+      pull-requests: write
     steps:
+      - name: Close abandoned PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # days-before-stale Idle number of days before marking issues/PRs stale (default: 60)
+          # days-before-close Idle number of days before closing stale issues/PRs (default: 7)
+
+          # Don't handle issues
+          # If set to a negative number like -1, the issues or the pull requests will never be closed automatically.
+          days-before-issue-stale: -1 # Override days-before-stale for issues only
+          days-before-issue-close: -1 # Override days-before-close for issues only
+
+          # Handle PRs
+          # Mark as stale after 30 days of inactivity and then for stale PRs close immediately
+          days-before-pr-stale: 30 # Override days-before-stale for PRs only
+          days-before-pr-close: 0 # Override days-before-close for PRs only
+          close-pr-label: autoclose # Label the PR as autoclosed
+
+          # Add comment to the PR when it is closed
+          close-pr-message: "Auto-closing: no activity for 30 days. If this is still relevant, reopen or create a fresh PR."
+
+          # Drafts dont create docs so leave them alone
+          exempt-draft-pr: true
+
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Close PRs older than 30 days.

Related: https://github.com/eclipse-score/score/issues/1029