### PR TITLE
Enable external needs json & increase versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_platform",
-    version = "0.1.1",
+    version = "0.2.0",
     compatibility_level = 0,
 )
 
@@ -90,5 +90,5 @@ bazel_dep(name = "score_cr_checker", version = "0.2.2")
 bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
 # Checker rule for CopyRight checks/fixs
 
-bazel_dep(name = "score_docs_as_code", version = "0.3.2")
+bazel_dep(name = "score_docs_as_code", version = "0.3.3")
 bazel_dep(name = "score_process", version = "0.2.0")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,3 +68,5 @@ needs_string_links: dict[str, dict[str, Any]] = {
         "options": ["source_code_link"],
     },
 }
+
+needs_builder_filter = ""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,5 +68,5 @@ needs_string_links: dict[str, dict[str, Any]] = {
         "options": ["source_code_link"],
     },
 }
-
+# This ensures all needs that are imported show up in the build 'needs.json'
 needs_builder_filter = ""


### PR DESCRIPTION
Currently all needs that are external (like process) will be filtered out in the 'needs.json'. 

This allows the needs.json to contain ALL of the needs imported. 

In a future PR the filter can probably be adapted to make it more efficent, e.g. only get external needs that are actually needed. 

~~## ⚠️  This PR should not be merged until new docs-as-code is out. As that has bugfixes that might be imported for here.~~

New docs-as-code version is available. PR can be reviewed and mered. 

--- 

I pulled the version to a new major one, as the change in needs.json is something that changes how it could be used.
I think that makes sense (at least in my head) .
