### PR TITLE
docs: Fix persistency tags

### DIFF
--- a/docs/features/persistency/kvs/requirements/index.rst
+++ b/docs/features/persistency/kvs/requirements/index.rst
@@ -301,7 +301,7 @@ Requirements
 
    The Key-Value-Storage shall support concurrent intra-process data access.
 
-.. needextend:: docname is not None
+.. needextend:: docname is not None and "persistency/kvs/requirements" in docname
    :+tags: persistency
 
 AoU Requirements

--- a/docs/modules/persistency/kvs/docs/requirements/index.rst
+++ b/docs/modules/persistency/kvs/docs/requirements/index.rst
@@ -389,5 +389,5 @@ Requirements
 
    The component shall provide an API for registering callbacks that are triggered by data change events.
 
-.. needextend:: docname is not None
+.. needextend:: docname is not None and "persistency/kvs/requirements" in docname
    :+tags: persistencykvs


### PR DESCRIPTION
Persistency tags to be added only to needs from persistency/kvs/requirements.

Related: https://github.com/eclipse-score/score/issues/1597