### PR TITLE
infra: Uplift docs_as_code 1.0.2 and score_process 1.1.1-Beta

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,5 +97,5 @@ bazel_dep(name = "score_cli_helper", version = "0.1.1")
 bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
 # Checker rule for CopyRight checks/fixs
 
-bazel_dep(name = "score_docs_as_code", version = "1.0.1")
-bazel_dep(name = "score_process", version = "1.1.0")
+bazel_dep(name = "score_docs_as_code", version = "1.0.2")
+bazel_dep(name = "score_process", version = "1.1.1-Beta")


### PR DESCRIPTION
Uplift score_process to match version from docs-as-code