### PR TITLE
Unify devcontainers

### DIFF
--- a/.devcontainer/alt_container_docker_on_windows/devcontainer.json
+++ b/.devcontainer/alt_container_docker_on_windows/devcontainer.json
@@ -1,5 +1,0 @@
-{
-    "name": "eclipse-s-core-docker-on-windows",
-    "image": "ghcr.io/eclipse-score/devcontainer:latest",
-    "initializeCommand": "IF not exist ${localEnv:HOME}\\.cache\\bazel ( mkdir ${localEnv:HOME}\\.cache\\bazel )"
-}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "eclipse-s-core",
     "image": "ghcr.io/eclipse-score/devcontainer:latest",
+    // This will run on Linux `initialize_command` and on Windows `initialize_command.bat`
     "initializeCommand": [
         ".devcontainer/initialize_command",
         "${localEnv:HOME}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
     "name": "eclipse-s-core",
     "image": "ghcr.io/eclipse-score/devcontainer:latest",
-    "initializeCommand": "mkdir -p ${localEnv:HOME}/.cache/bazel"
+    "initializeCommand": [
+        ".devcontainer/initialize_command",
+        "${localEnv:HOME}"
+    ]
 }

--- a/.devcontainer/initialize_command
+++ b/.devcontainer/initialize_command
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+# Create Bazel cache directory if it doesn't exist
+home="$1"
+mkdir -p "$home/.cache/bazel"

--- a/.devcontainer/initialize_command.cmd
+++ b/.devcontainer/initialize_command.cmd
@@ -1,0 +1,4 @@
+REM Create Bazel cache directory if it doesn't exist
+
+set home="%1"
+IF not exist "%home%\\.cache\\bazel" ( mkdir "%home%\\.cache\\bazel" )

--- a/docs/contribute/development/development_environment.rst
+++ b/docs/contribute/development/development_environment.rst
@@ -49,9 +49,6 @@ This approach simplifies the setup process and ensures a consistent development 
 
 **No** manual setup needs to be done when using the devcontainer.
 
-.. note::
-    If you are using Docker on Windows **without WSL2** in between, you have to select the alternative container `eclipse-s-core-docker-on-windows`.
-
 Manual Setup
 ============
 


### PR DESCRIPTION
Linux / WSL and Docker on Windows use different scripting languages and this shows in the initializeCommand. With this solution the same devcontainer.json file can be used on all platforms, which reduces maintenance costs.