### PR TITLE
Update default and custom Bazel modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Commonly used for local settings and secrets
 .env
-
+.venv_docs
 # Bazel
 bazel-*
 MODULE.bazel.lock

--- a/BUILD
+++ b/BUILD
@@ -11,10 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@score_cli_helper//:cli_helper.bzl", "cli_helper")
-load("@score_cr_checker//:cr_checker.bzl", "copyright_checker")
 load("@score_docs_as_code//:docs.bzl", "docs")
-load("@score_starpls_lsp//:starpls.bzl", "setup_starpls")
+load("@score_tooling//:defs.bzl", "cli_helper", "copyright_checker", "setup_starpls")
 
 test_suite(
     name = "format.check",
@@ -43,8 +41,8 @@ copyright_checker(
         "//:BUILD",
         "//:MODULE.bazel",
     ],
-    config = "@score_cr_checker//resources:config",
-    template = "@score_cr_checker//resources:templates",
+    config = "@score_tooling//cr_checker/resources:config",
+    template = "@score_tooling//cr_checker/resources:templates",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ use_repo(python)
 
 # Additional Python rules provided by aspect, e.g. an improved version of
 # `py_binary`. But more importantly, it provides `py_venv`.
-bazel_dep(name = "aspect_rules_py", version = "1.4.0")
+bazel_dep(name = "aspect_rules_py", version = "1.6.3")
 
 ###############################################################################
 #
@@ -58,44 +58,20 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
 # Generic linting and formatting rules
 #
 ###############################################################################
-bazel_dep(name = "aspect_rules_lint", version = "1.4.4")
+bazel_dep(name = "aspect_rules_lint", version = "1.5.3")
 
 ###############################################################################
 #
 # Java version
 #
 ###############################################################################
-bazel_dep(name = "rules_java", version = "8.13.0")
+bazel_dep(name = "rules_java", version = "8.15.1")
 
 ###############################################################################
 #
-# Misc. dependency
+# Score custom modules loading
 #
 ###############################################################################
-
-bazel_dep(name = "score_python_basics", version = "0.3.4")
-
-###############################################################################
-#
-# Checker rule for CopyRight checks/fixes
-#
-###############################################################################
-bazel_dep(name = "score_cr_checker", version = "0.3.1")
-
-###############################################################################
-#
-# CLI helper rule for CLI help
-#
-###############################################################################
-bazel_dep(name = "score_cli_helper", version = "0.1.1")
-
-###############################################################################
-#
-# StarPLS LSP server
-#
-###############################################################################
-bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
-# Checker rule for CopyRight checks/fixs
-
-bazel_dep(name = "score_docs_as_code", version = "1.0.2")
-bazel_dep(name = "score_process", version = "1.1.1")
+bazel_dep(name = "score_tooling", version = "1.0.1")
+bazel_dep(name = "score_docs_as_code", version = "1.1.0")
+bazel_dep(name = "score_process", version = "1.1.2")


### PR DESCRIPTION
Update these default bazel modules versions: 
- aspect_rules_py: 1.4.0 -> 1.6.3
- aspect_rules_lint: 1.4.4 -> 1.5.3
- rules_java: 8.13.0 -> 8.15.1

Update our custom bazel modules versions: 
- score_docs_as_code: 1.0.2 -> 1.1.1
- score_process: 1.1.1 -> 1.1.2

Integrate score_tooling and change the integration of all its used sub-modules

Note: After the update ide_support, docs build and tests are working well. 

close: https://github.com/eclipse-score/score/issues/1639