### PR TITLE
docs: Add section to git doc about fixing problems

### DIFF
--- a/docs/contribute/general/git.rst
+++ b/docs/contribute/general/git.rst
@@ -209,7 +209,7 @@ Correcting Mistakes
 ===================
 
 Sometimes it happens that mistakes are made in the commit history.
-This can usually be corrected.
+This can usually be corrected as long as they are not merged to main.
 
 Examples of problematic history include:
 


### PR DESCRIPTION
In case something goes wrong with git history, users should have the information how to fix problems.