### PR TITLE
ci: fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,9 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
       - name: Verify Doc-as-Code version
+        if: ${{ github.event_name == 'pull_request_target' }}
         id: doc_version
         run: |
           if python3 .github/scripts/check_doc_tool_version.py \
@@ -63,6 +65,7 @@ jobs:
           fi
 
       - name: Find Comment
+        if: ${{ github.event_name == 'pull_request_target' }}
         uses: peter-evans/find-comment@v3
         id: fc
         with:


### PR DESCRIPTION
Fix dac version check issue on merge to main.
Version check should run only on PR.

Closes: https://github.com/eclipse-score/score/issues/1818