### PR TITLE
fix: remove absolute file path

### DIFF
--- a/docs/features/baselibs/docs/architecture/index.rst
+++ b/docs/features/baselibs/docs/architecture/index.rst
@@ -94,7 +94,7 @@ Static Architecture
 Logical Interfaces
 ------------------
 
-The Baselibs feature exposes the following logical interfaces defined in the :doc:`/modules/baselibs/index`:
+The Baselibs feature exposes the following logical interfaces:
 
 .. needtable::
    :style: table


### PR DESCRIPTION
# Bugfix

## Description

Absolute file paths break the build, when used from somewhere else.
