### PR TITLE
lib/utils - Remove string_hash lib

### DIFF
--- a/docs/modules/baselibs/utils/docs/index.rst
+++ b/docs/modules/baselibs/utils/docs/index.rst
@@ -50,7 +50,6 @@ General considerations
 
 The Utils library should provide type-safe utility functions and efficient algorithms:
 
-* :need:`comp_req__utils__string_hash`
 * :need:`comp_req__utils__base64`
 * :need:`comp_req__utils__pimpl_ptr`
 * :need:`comp_req__utils__scoped_operation`

--- a/docs/modules/baselibs/utils/docs/requirements/index.rst
+++ b/docs/modules/baselibs/utils/docs/requirements/index.rst
@@ -25,16 +25,6 @@ Requirements
 Functional Requirements
 =======================
 
-.. comp_req:: String Hash Utilities
-   :id: comp_req__utils__string_hash
-   :reqtype: Functional
-   :security: NO
-   :safety: ASIL_B
-   :satisfies: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
-   :status: valid
-
-   The Utils library shall provide a function that accepts a string and returns its hash value.
-
 .. comp_req:: Base64 Encoding and Decoding
    :id: comp_req__utils__base64
    :reqtype: Functional


### PR DESCRIPTION
Baselibs FT is retiring the `utils` library. For now, the `string_hash` functionality is removed.