### PR TITLE
Switch to tagged devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,4 @@
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:latest",
-    // This will run on Linux `initialize_command` and on Windows `initialize_command.bat`
-    "initializeCommand": [
-        ".devcontainer/initialize_command",
-        "${localEnv:HOME}"
-    ]
+    "image": "ghcr.io/eclipse-score/devcontainer:0.1.0"
 }

--- a/.devcontainer/initialize_command
+++ b/.devcontainer/initialize_command
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -eu
-
-# Create Bazel cache directory if it doesn't exist
-home="$1"
-mkdir -p "$home/.cache/bazel"

--- a/.devcontainer/initialize_command.cmd
+++ b/.devcontainer/initialize_command.cmd
@@ -1,4 +1,0 @@
-REM Create Bazel cache directory if it doesn't exist
-
-set home="%1"
-IF not exist "%home%\\.cache\\bazel" ( mkdir "%home%\\.cache\\bazel" )


### PR DESCRIPTION
WIth this change, a semver-tagged devcontainer version is pinned. Thus, updates to the "latest" tag cannot unexpectedly cause harm to the repository anymore.