### PR TITLE
Align platform testing to process description naming

### DIFF
--- a/docs/platform_management_plan/safety_management.rst
+++ b/docs/platform_management_plan/safety_management.rst
@@ -92,7 +92,7 @@ The following  ISO 26262 defined safety work products are not relevant for the S
   Note that stakeholder requirements (:need:`std_wp__iso26262__system_651`) are in scope of the project,
   to be able to cover System and HW related failures which are usually covered by SW (e.g. end to end protection for ECU external communication).
   But those are the "Assumed Technical Safety Requirements" of the SW platform SEooC and do not need to be tested by SEooC supplier.
-  I.e. the system testing is out of scope. Note that S-CORE will implement platform test of stakeholder requirements for demonstration,
+  I.e. the system testing is out of scope. Note that S-CORE will implement Platform Integration Test of stakeholder requirements for demonstration,
   but these are not intended to be completely covering the stakeholder requirements.
   There will be SW integration tests of feature requirements, as required by ISO 26262 part 6-10.
   These may be reused by the users on their HW platform to cover Technical Safety Requirements towards the SW platform.

--- a/docs/platform_management_plan/software_verification.rst
+++ b/docs/platform_management_plan/software_verification.rst
@@ -130,7 +130,7 @@ There are the following different levels of integration and verification defined
   These tests serve as an optional base for the integrator and will also be part of the
   :need:`wp__verification_platform_ver_report`, but more on an informative character. The full scope
   of clause 11 is tailored out accordingly for S-Core. Practically, this means S-CORE will implement
-  platform test of stakeholder requirements for demonstration, but these are not intended to completely
+  Platform Integration Test of stakeholder requirements for demonstration, but these are not intended to completely
   covering all stakeholder requirements.
 
 Verification Methods


### PR DESCRIPTION
`Platform Test` was renamed to `Platform Integration Test` within the process description. This PR renames the occurrences of the wording in score repository to match process_description repository as a follow up of Pull Request https://github.com/eclipse-score/process_description/pull/233

Resolves: #1972