### PR TITLE
update process_description and doc-as-code version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,5 +73,5 @@ bazel_dep(name = "rules_java", version = "8.15.1")
 #
 ###############################################################################
 bazel_dep(name = "score_tooling", version = "1.0.2")
-bazel_dep(name = "score_docs_as_code", version = "2.0.0")
-bazel_dep(name = "score_process", version = "1.3.1")
+bazel_dep(name = "score_docs_as_code", version = "2.0.3")
+bazel_dep(name = "score_process", version = "1.3.2")

--- a/docs/modules/feo/feo/docs/index.rst
+++ b/docs/modules/feo/feo/docs/index.rst
@@ -59,7 +59,7 @@ Specification
 
    .. note::
       A CR shall specify the component requirements as part of our platform/project.
-      Thereby the :need:`rl__module_lead` will approve these requirements as part of accepting the CR (e.g. merging the PR with the CR).
+      Thereby the :need:`Module Lead <rl__committer>` will approve these requirements as part of accepting the CR (e.g. merging the PR with the CR).
 
 
 

--- a/docs/modules/persistency/kvs/docs/index.rst
+++ b/docs/modules/persistency/kvs/docs/index.rst
@@ -79,7 +79,7 @@ Specification
 
    .. note::
       A CR shall specify the component requirements as part of our platform/project.
-      Thereby the :need:`rl__module_lead` will approve these requirements as part of accepting the CR (e.g. merging the PR with the CR).
+      Thereby the :need:`Module Lead <rl__committer>` will approve these requirements as part of accepting the CR (e.g. merging the PR with the CR).
 
 
 Backwards Compatibility

--- a/docs/platform_management_plan/problem_resolution.rst
+++ b/docs/platform_management_plan/problem_resolution.rst
@@ -234,8 +234,8 @@ experts must confirm or disconfirm, if safety/security is affected is set correc
 
 :need:`gd_chklst__problem_cr_review` can help to verify whether the information is complete.
 
-In case affected parties need to be informed :need:`Technical Lead <rl__technical_lead>` or
-:need:`Module Lead <rl__module_lead>` will notify them, either updating the Assignees or
+In case affected parties need to be informed :need:`Project Lead <rl__project_lead>` or
+:need:`Module Lead <rl__committer>` will notify them, either updating the Assignees or
 adding labels for community or feature teams.
 
 Otherwise, if no Problem Resolution is planned, the problem is rejected. To reject the Problem

--- a/docs/platform_management_plan/security_management.rst
+++ b/docs/platform_management_plan/security_management.rst
@@ -165,7 +165,7 @@ Security Resources
 
 Security managers are elected by :need:`rl__project_lead` for all the S-CORE OoCs development.
 
-The security manager, supported by the project manager (i.e. the :need:`rl__technical_lead`),  will ensure that
+The security manager, supported by the project manager (i.e. the :need:`rl__project_lead`),  will ensure that
 security activities are actively planned, developed, analyzed, verified and tested and managed throughout the life cycle of the project.
 As all the implementation of security functions takes place within module development, there is a security manager appointed in the module's security plan.
 
@@ -205,12 +205,11 @@ The status report is based on security plans work product lists (see below) and 
 *Escalation*
 
 * Security Manager :need:`rl__security_manager` to steering committee documented in :need:`doc__project_mgt_plan`.
-* :need:`rl__technical_lead` to :need:`rl__project_lead`
 
 Examples for valid escalation causes are:
 
 * Security issues cannot be resolved on module level or with the available resources.
-* There are conflicting points of view between the Project Lead :need:`rl__project_lead`, Technical Lead :need:`rl__technical_lead`, Safety Manager :need:`rl__safety_manager`, Security Manager :need:`rl__security_manager` and the Quality Manager :need:`rl__quality_manager`
+* There are conflicting points of view between the Project Lead :need:`rl__project_lead`, Safety Manager :need:`rl__safety_manager`, Security Manager :need:`rl__security_manager` and the Quality Manager :need:`rl__quality_manager`
 
 Security Management Lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
doc-as-code: 2.0.3
process_description: 1.3.2

major changes, red color for ASIL B
removing rl__technical_lead and rl__module_lead