### PR TITLE
lib/containers - Add missing requirement for NonRelocatableVector

### DIFF
--- a/docs/modules/baselibs/containers/docs/requirements/index.rst
+++ b/docs/modules/baselibs/containers/docs/requirements/index.rst
@@ -55,6 +55,17 @@ Functional Requirements
 
    The Containers library shall enforce compile-time type safety for all container operations.
 
+.. comp_req:: Non-Relocatable Vector
+   :id: comp_req__containers__non_relocatable_vector
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :satisfies: feat_req__baselibs__core_utilities, feat_req__baselibs__containers_library, feat_req__baselibs__safety
+   :status: valid
+
+   The Containers library shall provide a non-relocatable vector container that maintains stable element addresses.
+
+
 Non-Functional Requirements
 ===========================
 


### PR DESCRIPTION
This adds a missing component requirement for https://github.com/eclipse-score/baselibs/blob/main/score/containers/non_relocatable_vector.h