### PR TITLE
bazel: fix module integration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,7 +26,7 @@ bazel_dep(name = "rules_python", version = "1.4.1")
 
 PYTHON_VERSION = "3.12"
 
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
 python.toolchain(
     configure_coverage_tool = True,
     is_default = True,
@@ -36,7 +36,7 @@ use_repo(python)
 
 # Additional Python rules provided by aspect, e.g. an improved version of
 # `py_binary`. But more importantly, it provides `py_venv`.
-bazel_dep(name = "aspect_rules_py", version = "1.6.3")
+bazel_dep(name = "aspect_rules_py", version = "1.6.3", dev_dependency = True)
 
 ###############################################################################
 #
@@ -72,6 +72,6 @@ bazel_dep(name = "rules_java", version = "8.15.1")
 # Score custom modules loading
 #
 ###############################################################################
-bazel_dep(name = "score_tooling", version = "1.0.2")
+bazel_dep(name = "score_tooling", version = "1.0.4")
 bazel_dep(name = "score_docs_as_code", version = "2.2.0")
 bazel_dep(name = "score_process", version = "1.4.0")


### PR DESCRIPTION
add dev dependecies to avoid collisions

# Bugfix

> [!IMPORTANT]
> Use this template only for bugfixes that do not influence topics covered by change requests or improvements.

> [!CAUTION]
> Make sure to submit your pull-request as **Draft** until you are ready to have it reviewed by the Committers.

## Description

Non dev dependencies were causing issues to python environment in `reference_integration` repository and did not allow creating venv resulting in failing pipelines.

## Related ticket

> [!IMPORTANT]
> Please replace `[ISSUE-NUMBER]` with the issue-number that tracks this bug fix. If there is no such
> ticket yet, create one via [this issue template](../ISSUE_TEMPLATE/new?template=bug_fix.md).

Relates: https://github.com/eclipse-score/reference_integration/issues/53
