### PR TITLE
Refine test level in PMP

### DIFF
--- a/docs/platform_management_plan/software_verification.rst
+++ b/docs/platform_management_plan/software_verification.rst
@@ -115,19 +115,18 @@ There are the following different levels of integration and verification defined
    #. component architecture and
    #. component requirements
 
-   This specifically addresses
-
 2. **Software integration verification** on feature level to verify the integration of components to a feature based on
 
    #. feature architecture and
    #. feature requirements
 
-3. **Testing of the embedded software** as Platform Integration Testing (on reference hardware)
+3. **Software platform verification** as Platform Integration Testing of the integrated software element (on reference hardware) based on
 
    #. Stakeholder requirements
 
 
-  **Note:** These three levels from 1 to 3 translate to the levels of ISO 26262 part 6 clauses 9 (unit) to 11 (embedded software).
+  **Note:** These three levels translate to the levels of ISO 26262 part 6 clauses 9 to 11, where compliant testing with full coverage is tailored out for the embedded software.
+  The specific tailoring is described in the :need:`doc__score_platform_safety_plan`.
   The full Platform Integration Testing will be executed by the integrator. S-CORE project only executes tests on reference hardware.
   These tests serve as an optional base for the integrator and will also be part of the
   :need:`wp__verification_platform_ver_report`, but more on an informative character. The full scope


### PR DESCRIPTION
Further refinement for audit Deviation_13 and Action_43 which was covered already by earlier commits.

Action taken:
- The methods table is reworked in accordance to the mapping of the specified test levels to the ISO 26262 test levels.
- The mapping of the test levels to the ISO 26262-6 test levels is further clarified in the verification plan as part of the PMP

Part of: https://github.com/eclipse-score/process_description/issues/80