### PR TITLE
Update CODEOWNERS for PMP part

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,7 +33,7 @@ verification/                         @eclipse-score/automotive-score-committers
 /docs/manuals/                        @eclipse-score/automotive-score-committers
 /docs/modules/                        @eclipse-score/automotive-score-committers
 # /docs/platform_management_plan/     @eclipse-score/community-process
-/docs/platform_management_plan/       @pahmann @PhilipPartsch @masc2023 @aschemmel-tech
+/docs/platform_management_plan/       @pahmann @PhilipPartsch @masc2023 @aschemmel-tech @PandaeDo
 # /docs/quality/                      @eclipse-score/quality-managers
 /docs/quality/                        @masc2023 @pahmann @PandaeDo
 # /docs/requirements/stakeholder/     @eclipse-score/automotive-score-technical-leads


### PR DESCRIPTION
@PandaeDo is safety manager and quality manager, but misses the right to submit approving of the PMP, which should be changed by an update of the CODEOWNER file.

