### PR TITLE
Update language for gender neutrality in project management plan

### DIFF
--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -43,7 +43,7 @@ Steering of the project is done by two committees: *project lead circle* and *te
   * Election of Technical Leads.
   * Last instance of escalation path.
 
-  *Project lead circle* proposes and elects a *Project lead circle Assistant* and his deputy with bare majority, who is responsible for scheduling and announcing meetings, preparing and announcing agenda, writing meeting minutes and protocols. *Project lead circle* can reelect *Project lead circle Assistant* at any time. The *Project lead circle Assistant* and his deputy can resign anytime on their own will.
+  *Project lead circle* proposes and elects a *Project lead circle Assistant* and their deputy with bare majority, who is responsible for scheduling and announcing meetings, preparing and announcing agenda, writing meeting minutes and protocols. *Project lead circle* can reelect *Project lead circle Assistant* at any time. The *Project lead circle Assistant* and their deputy can resign anytime on their own will.
 
 * **Technical lead circle**
 
@@ -54,7 +54,7 @@ Steering of the project is done by two committees: *project lead circle* and *te
   * High-level project control and coordination between multiple software modules.
   * Escalation instance for software module project leads and committers.
 
-  *Technical lead circle* proposes and elects a *Technical lead circle Assistant* and his deputy with bare majority during *Technical Lead Circle meeting*, who is responsible for scheduling and announcing meetings, preparing and announcing agenda, writing meeting minutes and protocols. *Technical lead circle* can reelect *Technical lead circle Assistant* at any time. The *Technical lead circle Assistant* and his deputy can resign anytime on their own will.
+  *Technical lead circle* proposes and elects a *Technical lead circle Assistant* and their deputy with bare majority during *Technical Lead Circle meeting*, who is responsible for scheduling and announcing meetings, preparing and announcing agenda, writing meeting minutes and protocols. *Technical lead circle* can reelect *Technical lead circle Assistant* at any time. The *Technical lead circle Assistant* and their deputy can resign anytime on their own will.
 
 .. _pmp_pm_technical_committees:
 

--- a/docs/platform_management_plan/release_management.rst
+++ b/docs/platform_management_plan/release_management.rst
@@ -50,7 +50,7 @@ One release contains all the files of one repository. So there is a platform rel
 It contains also all the verification reports (including their input e.g. test run logs) and documentation collaterals
 (e.g. the html's for the S-CORE homepage) as created during the CI build based on the release tagged repository files.
 It does not contain the binary produced in the CI build, as this is not a qualified work product of S-CORE and
-the user will need to re-build in the context of his system. Furthermore the binary build with Bazel
+the user will need to re-build in the context of their system. Furthermore the binary build with Bazel
 is reproducible, so this can be re-created from source any time.
 
 Release Types

--- a/docs/platform_management_plan/security_management.rst
+++ b/docs/platform_management_plan/security_management.rst
@@ -143,7 +143,7 @@ As defined in `Committer Training <https://www.eclipse.org/projects/training/>`_
 
 As each project can adopt additional criteria for the committers election, we define the following:
 
-each committer has to prove his knowledge in security SW development by
+each committer has to prove their knowledge in security SW development by
 
 * an absolved training in ISO SAE 21434 (or equivalent standard, at least 16h of SW development specific training by a trusted training provider) OR
 * by attending the projects's ISO SAE 21434 SW development training (given by a security team member)


### PR DESCRIPTION
There was a usage of "his" in the PMP which got updated to a neutral "their" to be neutral and welcoming 
This is done e.g. to follow the community code of conduct.