### PR TITLE
Add link for embedded SW tailoring in verification plan

### DIFF
--- a/docs/platform_management_plan/software_verification.rst
+++ b/docs/platform_management_plan/software_verification.rst
@@ -141,9 +141,9 @@ There are the following different levels of integration and verification defined
   The full Platform Integration Testing will be executed by the integrator. S-CORE project only executes tests on reference hardware.
   These tests serve as an optional base for the integrator and will also be part of the
   :need:`wp__verification_platform_ver_report`, but more on an informative character. The full scope
-  of clause 11 is tailored out accordingly for S-CORE (see: :need:`gd_guidl__verification_req_tailored`). Practically, this means S-CORE will implement
-  Platform Integration Test of stakeholder requirements for demonstration, but these are not intended to completely
-  covering all stakeholder requirements.
+  of clause 11 is tailored out accordingly for S-CORE (see: :need:`gd_guidl__verification_req_tailored`).
+  Practically, this means S-CORE will implement Platform Integration Tests for stakeholder requirements for demonstration,
+  but these are not intended to completely covering all stakeholder requirements.
 
 Verification Methods
 --------------------


### PR DESCRIPTION
Improve the link to tailoring of the embedded software by pointing to the process_description verification process tailoring need.