### PR TITLE
Add statement on coverage goals

### DIFF
--- a/docs/platform_management_plan/software_verification.rst
+++ b/docs/platform_management_plan/software_verification.rst
@@ -329,6 +329,9 @@ to be reached with every contribution.
 
 Further quality goals are defined in section :doc:`quality_management`.
 
+The confirmation or any deviation of the coverage percentage value is documented in this section.
+This shall also be part of the module documenation with a reasoning when percentage numbers deviate for an official release.
+
 Coverage of detailed design
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
It may not be feasible to achieve always a 100% coverage. When this is the case, there need to be a way to record this deviation and make it part of the documentation. As numbers are reported in CI this will pop up in audits and it can be checked if argumentation is provided.