### PR TITLE
fix(docs): add mandatory link

### DIFF
--- a/docs/features/configuration/config_model/index.rst
+++ b/docs/features/configuration/config_model/index.rst
@@ -7,6 +7,7 @@ Configuration Model
    :safety: QM
    :security: NO
    :tags: feature_request
+   :realizes: wp__feat_request
 
 Feature flag
 ============


### PR DESCRIPTION
# Bugfix

## Description

docs build is broken

root cause: merge of old branch

Can be prevented via `merge queues` or `Require branches to be up to date before merging`. We'll discuss that async.

## Related ticket

https://github.com/eclipse-score/docs-as-code/issues/369