### PR TITLE
Fixes permissions bug for bazel commands

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ use_repo(python)
 
 # Additional Python rules provided by aspect, e.g. an improved version of
 # `py_binary`. But more importantly, it provides `py_venv`.
-bazel_dep(name = "aspect_rules_py", version = "1.6.3", dev_dependency = True)
+bazel_dep(name = "aspect_rules_py", version = "1.6.6", dev_dependency = True)
 
 ###############################################################################
 #


### PR DESCRIPTION
This fixes a permissions bug when running bazel commands. Version 1.6.3 does not seem to be compatible with rules_py 1.8.3.

An upgrade to 1.8.4 of aspect_rules_py (newest version) was tried but that runs into other issues and is not a viable solution without further changes

Fixes: #2565