### PR TITLE
Remove unused mitigation_issue field from Development failure initiators section in DFA documentation

### DIFF
--- a/docs/features/persistency/safety_analysis/dfa.rst
+++ b/docs/features/persistency/safety_analysis/dfa.rst
@@ -79,7 +79,6 @@ Development failure initiators
    :failure_id: UI_01_06
    :failure_effect: Blocking of execution. This will lead to a unavailability of the persistency feature.
    :mitigated_by: aou_req__persistency__appl_exec
-   :mitigation_issue:
    :sufficient: yes
    :status: valid
 


### PR DESCRIPTION
# Bugfix

## Description

- Remove the empty `mitigation_issue` attribute from
  `feat_saf_dfa__persistency__execution_blocking`, which violates the metamodel
  pattern `^https://github.com/.*$`.

This fix is required because `score-docs-as-code` now generates sphinx-needs 6
schema definitions (`schemas.json`) from the S-CORE metamodel. These schemas are
evaluated at parse time on **all** needs, including those pulled from external
repositories. The empty string `""` was previously silently accepted by the
Python-based post-build checks but is now correctly rejected by the schema
validation, which enforces that `mitigation_issue`, if present, must be a valid
GitHub URL.

See also: #394

## Related ticket

> [!IMPORTANT]
> Please replace `[ISSUE-NUMBER]` with the issue-number that tracks this bug fix. If there is no such
> ticket yet, create one via [this issue template](../ISSUE_TEMPLATE/new?template=bug_fix.md).

closes #2582 (bugfix ticket)
