### PR TITLE
Add 'score' prefix

### DIFF
--- a/docs/platform_management_plan/safety_management.rst
+++ b/docs/platform_management_plan/safety_management.rst
@@ -381,7 +381,7 @@ Functional Safety/Security Management SW Platform Work Products
 
     * - :need:`wp__verification_platform_ver_report`
       - :ndf:`copy('status', need_id='wf__verification_platform_ver_report')`
-      - :need:`doc__platform_verification_report`
+      - :need:`doc__score_platform_verification_report`
       - draft
 
     * - :need:`wp__requirements_stkh`
@@ -433,17 +433,17 @@ Functional Safety Specific SW Platform Work Products
 
     * - :need:`wp__fdr_reports` (platform Safety Plan)
       - :ndf:`copy('status', need_id='wf__p_formal_rv')`
-      - :need:`doc__platform_safety_plan_fdr`
+      - :need:`doc__score_platform_safety_plan_fdr`
       - draft
 
     * - :need:`wp__fdr_reports` (platform Safety Package)
       - :ndf:`copy('status', need_id='wf__p_formal_rv')`
-      - :need:`doc__platform_safety_package_fdr`
+      - :need:`doc__score_platform_safety_package_fdr`
       - draft
 
     * - :need:`wp__fdr_reports` (feature's Safety Analyses & DFA)
       - :ndf:`copy('status', need_id='wf__p_formal_rv')`
-      - :need:`doc__platform_safety_analysis_fdr`
+      - :need:`doc__score_platform_safety_analysis_fdr`
       - draft
 
     * - :need:`wp__audit_report`
@@ -458,7 +458,7 @@ Functional Safety Specific SW Platform Work Products
 
     * - :need:`wp__platform_safety_manual`
       - :ndf:`copy('status', need_id='wf__cr_mt_safety_manual')`
-      - :need:`doc__platform_safety_manual`
+      - :need:`doc__score_platform_safety_manual`
       - draft
 
     * - :need:`wp__safety_tailoring` (generic)

--- a/docs/safety/fdr_reports_safety_analyses_DFA.rst
+++ b/docs/safety/fdr_reports_safety_analyses_DFA.rst
@@ -17,7 +17,7 @@ Safety Analysis Formal Review Report
 ====================================
 
 .. document:: Safety Analysis Formal Review Report
-   :id: doc__platform_safety_analysis_fdr
+   :id: doc__score_platform_safety_analysis_fdr
    :status: draft
    :safety: ASIL_B
    :security: NO

--- a/docs/safety/fdr_reports_safety_package.rst
+++ b/docs/safety/fdr_reports_safety_package.rst
@@ -17,7 +17,7 @@ Safety Package Formal Review Report
 ===================================
 
 .. document:: Platform Safety Package Formal Review
-   :id: doc__platform_safety_package_fdr
+   :id: doc__score_platform_safety_package_fdr
    :status: draft
    :safety: ASIL_B
    :security: NO

--- a/docs/safety/fdr_reports_safety_platform_safety_plan.rst
+++ b/docs/safety/fdr_reports_safety_platform_safety_plan.rst
@@ -17,7 +17,7 @@ Safety Plan Formal Review Report
 ================================
 
 .. document:: S-CORE Platform Safety Plan Formal Review
-   :id: doc__platform_safety_plan_fdr
+   :id: doc__score_platform_safety_plan_fdr
    :status: draft
    :safety: ASIL_B
    :security: NO

--- a/docs/safety/platform_safety_manual.rst
+++ b/docs/safety/platform_safety_manual.rst
@@ -17,7 +17,7 @@ Platform Safety Manual
 ======================
 
 .. document:: Platform Safety Manual
-   :id: doc__platform_safety_manual
+   :id: doc__score_platform_safety_manual
    :status: draft
    :safety: ASIL_B
    :security: NO

--- a/docs/score_releases/verification/platform_ver_report.rst
+++ b/docs/score_releases/verification/platform_ver_report.rst
@@ -16,7 +16,7 @@ Platform Verification Report
 ============================
 
 .. document:: Platform Verification Report
-   :id: doc__platform_verification_report
+   :id: doc__score_platform_verification_report
    :status: draft
    :safety: ASIL_B
    :security: NO


### PR DESCRIPTION
The needs: 

doc__platform_verification_report
doc__platform_safety_manual
doc__platform_safety_plan_fd
doc__platform_safety_package_fdr
doc__platform_safety_analysis_fdr

Were all added without a `score` prefix, therefore the build ran into an error due to them existing here and in process.
This PR adds the prefix & fixes the build error.