### PR TITLE
Add version to Docs-as-code

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ bazel_dep(name = "rules_java", version = "8.15.1")
 #
 ###############################################################################
 bazel_dep(name = "score_tooling", version = "1.1.2")
-bazel_dep(name = "score_docs_as_code")
+bazel_dep(name = "score_docs_as_code", version = "3.0.1")
 git_override(
     module_name = "score_docs_as_code",
     commit = "21640ab325b3aae147ba4e3e8b5e7ab89fc2e8f5",


### PR DESCRIPTION
Docs-as-code has to have a version for consumer tests to work.  Each 'bazel_dep' should **always** have a version.