### PR TITLE
Add belongs_to relationship to EBcLfSA, fixing build

### DIFF
--- a/docs/modules/os/operating_systems/docs/community/ebclfsa.rst
+++ b/docs/modules/os/operating_systems/docs/community/ebclfsa.rst
@@ -17,6 +17,7 @@
    :security: YES
    :safety: QM
    :status: valid
+   :belongs_to: feat__os
 
 EB corbos Linux for Safety Applications (EBcLfSA)
 #################################################


### PR DESCRIPTION
`comp__os_ebclfsa` is missing `:belongs_to: feat__os`. This dependency type was recently added via https://github.com/eclipse-score/score/pull/2703 but got never updated to the EBcLfSA PR. The documentation build is failing since the merge of #2708.