### PR TITLE
increase process version to 1.5.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,8 +79,8 @@ single_version_override(
     version = "4.0.0",
 )
 
-bazel_dep(name = "score_process", version = "1.5.1")
+bazel_dep(name = "score_process", version = "1.5.3")
 single_version_override(
     module_name = "score_process",
-    version = "1.5.1",
+    version = "1.5.3",
 )

--- a/docs/design_decisions/DR-007-infra.rst
+++ b/docs/design_decisions/DR-007-infra.rst
@@ -52,7 +52,7 @@ This tight coupling makes maintenance and evolution of both repositories difficu
 
 The artifacts within those repos are:
 
-* "examples" are exemplary instances of the metamodel like :need:`feat__example_feature`.
+* "examples" are exemplary instances of the metamodel like `feat__example_feature` in the process description.
 * "templates" (more precisely `folder templates <https://eclipse-score.github.io/process_description/main/folder_templates/index.html>`_)
   are instances which can be copied when creating new modules
   like :need:`doc__feature_name_architecture`.

--- a/docs/modules/communication/frontent/docs/architecture/index.rst
+++ b/docs/modules/communication/frontent/docs/architecture/index.rst
@@ -31,7 +31,7 @@ Frontend Component Architecture
    :status: valid
    :uses: logic_arc_int__logging__logging, logic_arc_int__tracing__tracing
    :belongs_to: comp__com_frontend
-   :fulfils: comp_req__component_name__some_title
+   :fulfils: comp_req__communication__logging
 
    .. needarch::
       :scale: 50
@@ -94,3 +94,18 @@ Frontend Component Architecture
    :safety:  ASIL_B
    :status: valid
    :included_by: logic_arc_int__communication__user
+
+
+Functional Requirements
+=======================
+
+.. comp_req:: Error logging
+   :id: comp_req__communication__logging
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :satisfies: feat_req__com__event_type
+   :status: valid
+   :belongs_to: comp__com_frontend
+
+   In case, that there is no related Event Type Info source provided in shared memory for a given Event enlisted in the deployment for the proxy, an ERROR message shall be logged.

--- a/docs/modules/logging/logging/docs/architecture/index.rst
+++ b/docs/modules/logging/logging/docs/architecture/index.rst
@@ -22,14 +22,6 @@ Component Architecture
    :implements: logic_arc_int__logging__logging
    :belongs_to: feat__logging
 
-.. comp_arc_sta:: Logging
-   :id: comp_arc_sta__logging__logging
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :belongs_to: comp__logging
-   :fulfils: comp_req__component_name__some_title
-
    .. needarch::
       :scale: 50
       :align: center

--- a/docs/modules/orchestrator/executor/docs/architecture/index.rst
+++ b/docs/modules/orchestrator/executor/docs/architecture/index.rst
@@ -69,16 +69,6 @@ The components are designed to cover the expectations from the feature architect
    :uses: logic_arc_int__logging__logging, logic_arc_int__tracing__tracing
    :belongs_to: feat__orchestration
 
-
-.. comp_arc_sta:: Executor
-   :id: comp_arc_sta__orch__executor
-   :security: YES
-   :safety:  ASIL_B
-   :status: valid
-   :uses: logic_arc_int__logging__logging, logic_arc_int__tracing__tracing
-   :belongs_to: comp__orch_executor
-   :fulfils: comp_req__component_name__some_title
-
    .. needarch::
       :scale: 50
       :align: center

--- a/docs/modules/orchestrator/orchestrator/docs/architecture/index.rst
+++ b/docs/modules/orchestrator/orchestrator/docs/architecture/index.rst
@@ -56,22 +56,8 @@ Mandatory: a motivation for the decomposition or reason for not further splittin
 .. note:: Common decisions across components / cross cutting concepts is at the higher level.
 
 
-
-
-
 Component Architecture
 =======================
-
-
-
-
-
-
-
-
-
-
-
 
 Static Architecture
 -------------------
@@ -103,7 +89,7 @@ The components are designed to cover the expectations from the feature architect
    :status: valid
    :uses: logic_arc_int__logging__logging, logic_arc_int__tracing__tracing, logic_arc_int__communication__user
    :belongs_to: comp__orchestrator
-   :fulfils: comp_req__component_name__some_title
+   :fulfils: comp_req__orchestrator__deploy
 
    .. needarch::
       :scale: 50
@@ -287,6 +273,34 @@ Interfaces
 ..       :safety: <QM|ASIL_B>
 ..       :fulfils: <link to component requirement id>
 ..       :language: cpp
+
+
+Functional Requirements
+=======================
+
+.. comp_req:: Error logging
+   :id: comp_req__orchestrator__logging
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :satisfies: feat_req__orchestration__obsv_trace_corr
+   :status: valid
+   :belongs_to: comp__orchestrator
+
+   In case, that there is an fault in the orchestration an ERROR message shall be logged.
+
+
+.. comp_req:: Error logging
+   :id: comp_req__orchestrator__deploy
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :satisfies: feat_req__orchestration__orch_single_deploy
+   :status: valid
+   :belongs_to: comp__orchestrator
+
+   The orchestrator shall provide an design interface.
+
 
 Lower Level Components
 ----------------------

--- a/docs/modules/os/libc/docs/architecture/index.rst
+++ b/docs/modules/os/libc/docs/architecture/index.rst
@@ -23,15 +23,6 @@ libc Component Architecture
    :implements: logic_arc_int__os__fcntl, logic_arc_int__os__stat, logic_arc_int__os__mman, logic_arc_int__os__unistd
    :belongs_to: feat__os
 
-.. comp_arc_sta:: libc
-   :id: comp_arc_sta__os__libc
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :satisfies:
-   :belongs_to: comp__os_libc
-   :fulfils: comp_req__component_name__some_title
-
    .. needarch::
       :scale: 50
       :align: center

--- a/docs/modules/os/libcpp/docs/architecture/index.rst
+++ b/docs/modules/os/libcpp/docs/architecture/index.rst
@@ -15,22 +15,13 @@
 libcpp Component Architecture
 *****************************
 
-.. comp:: libcpp
+.. comp:: libcpp (C++ Std Library)
    :id: comp__os_libcpp
    :status: valid
    :safety: ASIL_B
    :implements: logic_arc_int__os__libcpp
    :security: YES
    :belongs_to: feat__os
-
-.. comp_arc_sta:: C++ Std Library
-   :id: comp_arc_sta__os__libcpp
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :satisfies:
-   :belongs_to: comp__os_libcpp
-   :fulfils: comp_req__component_name__some_title
 
    .. needarch::
       :scale: 50

--- a/docs/modules/os/message_passing/docs/architecture/index.rst
+++ b/docs/modules/os/message_passing/docs/architecture/index.rst
@@ -24,15 +24,6 @@ Message Passing Component Architecture
    :satisfies:
    :belongs_to: feat__os
 
-
-.. comp_arc_sta:: QNX::Message Passing Static View
-   :id: comp_arc_sta__os__message_passing
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :belongs_to: comp__os_message_passing
-   :fulfils: comp_req__component_name__some_title
-
    .. needarch::
       :scale: 50
       :align: center

--- a/docs/modules/tracing/tracing/docs/architecture/index.rst
+++ b/docs/modules/tracing/tracing/docs/architecture/index.rst
@@ -23,14 +23,6 @@ Tracing Component Architecture
    :implements: logic_arc_int__tracing__tracing
    :belongs_to: feat__tracing
 
-.. comp_arc_sta:: Tracing
-   :id: comp_arc_sta__tracing__tracing
-   :security: YES
-   :safety: ASIL_B
-   :status: valid
-   :belongs_to: comp__tracing
-   :fulfils: comp_req__component_name__some_title
-
    .. needarch::
       :scale: 50
       :align: center


### PR DESCRIPTION
Increase process version to 1.5.3.
For this additional remove component architecture for components without substructure
Replace dummy requirements for components (where needed) from process examples by correct ones. This is a preparation to move this requirements to the module repository according to the "independent module design decision"

Fixes #2779