### PR TITLE
fix: update safety attribute

### DIFF
--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -26,7 +26,7 @@ Requirements
    :id: feat_req__baselibs__core_utilities
    :reqtype: Functional
    :security: NO
-   :safety: QM
+   :safety: ASIL_B
    :satisfies: stkh_req__functional_req__base_libraries
    :status: valid
 

--- a/docs/features/persistency/requirements/index.rst
+++ b/docs/features/persistency/requirements/index.rst
@@ -49,7 +49,7 @@ Requirements
    :id: feat_req__persistency__variant_management
    :reqtype: Non-Functional
    :security: NO
-   :safety: QM
+   :safety: ASIL_B
    :satisfies: stkh_req__overall_goals__variant_management
    :status: valid
 


### PR DESCRIPTION
feat_req__baselibs__core_utilities must be ASIL-B because feat_arc_sta__baselibs__static_view_arch and
feat_arc_dyn__baselibs__dynamic_view_arch fulfill it and these are ASIL-B.

Same with feat_req__persistency__variant_management and feat_arc_sta__persistency__static.