### PR TITLE
fix: orchestrator no longer changes process elements (2)

### DIFF
--- a/docs/modules/orchestrator/orchestrator/docs/requirements/index.rst
+++ b/docs/modules/orchestrator/orchestrator/docs/requirements/index.rst
@@ -62,5 +62,5 @@ Requirements
     - Set the status to valid and start the review/merge process
     - Add other needed requirements for your feature
 
-.. needextend:: "component_name" in id
+.. needextend:: "component_name" in id and is_external == False
    :+tags: component_name


### PR DESCRIPTION
needextend may not modify external needs, this is enforced in latest docs-as-code version