### PR TITLE
Fix: Needextends should not touch external needs

### DIFF
--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -166,5 +166,5 @@ Requirements
 
    The base libraries shall provide a library for parallel execution of C++ callables with thread pool management.
 
-.. needextend:: docname is not None and "__baselibs" in id 
+.. needextend:: is_external == False and "__baselibs" in id 
    :+tags: baselibs

--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -166,5 +166,5 @@ Requirements
 
    The base libraries shall provide a library for parallel execution of C++ callables with thread pool management.
 
-.. needextend:: "__baselibs" in id
+.. needextend:: docname is not None and "__baselibs" in id 
    :+tags: baselibs

--- a/docs/features/communication/docs/requirements/index.rst
+++ b/docs/features/communication/docs/requirements/index.rst
@@ -643,5 +643,5 @@ Safety Impact
 
    The communication framework shall support safe communication up to ASIL-B.
 
-.. needextend:: docname is not None and "__com_" in id
+.. needextend:: is_extrnal == False and "__com_" in id
    :+tags: com

--- a/docs/features/communication/docs/requirements/index.rst
+++ b/docs/features/communication/docs/requirements/index.rst
@@ -643,5 +643,5 @@ Safety Impact
 
    The communication framework shall support safe communication up to ASIL-B.
 
-.. needextend:: is_extrnal == False and "__com_" in id
+.. needextend:: is_external == False and "__com_" in id
    :+tags: com

--- a/docs/features/communication/docs/requirements/index.rst
+++ b/docs/features/communication/docs/requirements/index.rst
@@ -643,5 +643,5 @@ Safety Impact
 
    The communication framework shall support safe communication up to ASIL-B.
 
-.. needextend:: "__com_" in id
+.. needextend:: docname is not None and "__com_" in id
    :+tags: com

--- a/docs/features/communication/ipc/docs/requirements/index.rst
+++ b/docs/features/communication/ipc/docs/requirements/index.rst
@@ -65,5 +65,5 @@ Requirements
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
    criticality level.
 
-.. needextend:: docname is not None and "__ipc" in id
+.. needextend:: is_external == False and "__ipc" in id
    :+tags: ipc

--- a/docs/features/communication/ipc/docs/requirements/index.rst
+++ b/docs/features/communication/ipc/docs/requirements/index.rst
@@ -65,5 +65,5 @@ Requirements
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
    criticality level.
 
-.. needextend:: "__ipc" in id
+.. needextend:: docname is not None and "__ipc" in id
    :+tags: ipc

--- a/docs/features/frameworks/feo/requirements/aou_req.rst
+++ b/docs/features/frameworks/feo/requirements/aou_req.rst
@@ -32,5 +32,5 @@ FEO Feature Assumption of Use Requirements
 
    Something shall be done.
 
-.. needextend:: docname is not None and "frameworks/feo/requirements" in docname
+.. needextend:: is_external == False and "frameworks/feo/requirements" in docname
    :+tags: frameworks_feo

--- a/docs/features/frameworks/feo/requirements/feature_req.rst
+++ b/docs/features/frameworks/feo/requirements/feature_req.rst
@@ -322,5 +322,5 @@ Error Handling for S-CORE v0.5
     If an activity fails in the shutdown function, the primary process shall shutdown all remaining activities
     in arbitrary sequence and terminate itself.
 
-.. needextend:: docname is not None and "frameworks/feo/requirements" in docname
+.. needextend:: is_external == False and "frameworks/feo/requirements" in docname
    :+tags: frameworks_feo

--- a/docs/features/orchestration/requirements/index.rst
+++ b/docs/features/orchestration/requirements/index.rst
@@ -364,5 +364,5 @@ General Constraints
 
    The system shall use the approved IPC feature exclusively for all inter-process synchronization.
 
-.. needextend:: docname is not None and "orchestration/requirements" in docname
+.. needextend:: is_external == False and "orchestration/requirements" in docname
    :+tags: orchestration

--- a/docs/features/persistency/architecture/index.rst
+++ b/docs/features/persistency/architecture/index.rst
@@ -170,5 +170,5 @@ Logical Interfaces
 
    .. uml:: _assets/kvs_interface.puml
 
-.. needextend:: docname is not None and "persistency/kvs/architecture" in docname
+.. needextend:: is_external == False and "persistency/kvs/architecture" in docname
    :+tags: persistency

--- a/docs/features/persistency/requirements/index.rst
+++ b/docs/features/persistency/requirements/index.rst
@@ -476,7 +476,7 @@ Requirements
    The Persistency shall support the production mode.
    The production mode should enforce the most restrictive data access controls feasible.
 
-.. needextend:: docname is not None and "persistency/requirements" in docname
+.. needextend:: is_external == False and "persistency/requirements" in docname
    :+tags: persistency
 
 

--- a/docs/modules/communication/docs/requirements/aou_req.rst
+++ b/docs/modules/communication/docs/requirements/aou_req.rst
@@ -343,5 +343,5 @@ Assumptions of Use
    It shall be ensured that all safety relevant events/fields in the service type,
    are the same in all configurations.
 
-.. needextend:: "__communication_" in id
+.. needextend:: docname is not None and "__communication_" in id
    :+tags: communication

--- a/docs/modules/communication/docs/requirements/aou_req.rst
+++ b/docs/modules/communication/docs/requirements/aou_req.rst
@@ -343,5 +343,5 @@ Assumptions of Use
    It shall be ensured that all safety relevant events/fields in the service type,
    are the same in all configurations.
 
-.. needextend:: docname is not None and "__communication_" in id
+.. needextend:: is_external == False and "__communication_" in id
    :+tags: communication

--- a/docs/modules/communication/lola/docs/requirements/index.rst
+++ b/docs/modules/communication/lola/docs/requirements/index.rst
@@ -31,5 +31,5 @@ see `LoLa trlc <https://github.com/eclipse-score/communication/blob/main/score/m
 LoLa component Assumptions of Use
 =================================
 
-.. needextend:: docname is not None and "lola" in id
+.. needextend:: is_external == False and "lola" in id
    :+tags: lola

--- a/docs/modules/communication/lola/docs/requirements/index.rst
+++ b/docs/modules/communication/lola/docs/requirements/index.rst
@@ -31,5 +31,5 @@ see `LoLa trlc <https://github.com/eclipse-score/communication/blob/main/score/m
 LoLa component Assumptions of Use
 =================================
 
-.. needextend:: "lola" in id
+.. needextend:: docname is not None and "lola" in id
    :+tags: lola

--- a/docs/modules/feo/feo/docs/architecture/component_architecture.rst
+++ b/docs/modules/feo/feo/docs/architecture/component_architecture.rst
@@ -160,5 +160,5 @@ Interfaces
 
   See static architecture.
 
-.. needextend:: docname is not None and "feo/docs/architecture" in docname
+.. needextend:: is_external == False and "feo/docs/architecture" in docname
    :+tags: component_feo

--- a/docs/modules/feo/feo/docs/requirements/aou_req.rst
+++ b/docs/modules/feo/feo/docs/requirements/aou_req.rst
@@ -33,5 +33,5 @@ FEO Component Assumption of Use Requirements
 
    Anything shall be done.
 
-.. needextend:: docname is not None and "feo/docs/requirements" in docname
+.. needextend:: is_external == False and "feo/docs/requirements" in docname
    :+tags: component_feo

--- a/docs/modules/feo/feo/docs/requirements/component_requirements.rst
+++ b/docs/modules/feo/feo/docs/requirements/component_requirements.rst
@@ -375,8 +375,8 @@ Error Handling for S-CORE v0.5
     If an activity fails in the shutdown function, the primary process shall shutdown all remaining activities
     in arbitrary sequence and terminate itself.
 
-.. needextend:: docname is not None and "feo/docs/requirements" in docname
+.. needextend:: is_external == False and "feo/docs/requirements" in docname
    :+tags: component_feo
 
-.. needextend:: docname is not None and "feo/docs/requirements" in docname and type == "comp_req"
+.. needextend:: is_external == False and "feo/docs/requirements" in docname and type == "comp_req"
    :+belongs_to: comp__feo_main

--- a/docs/modules/os/docs/requirements/aou_req.rst
+++ b/docs/modules/os/docs/requirements/aou_req.rst
@@ -79,5 +79,5 @@ Generic Assumptions of Use
 
    Note3: Another example is mmap_peer which would allow accessing other processes memory if wrongly used.
 
-.. needextend:: docname is not None and "__os_" in id
+.. needextend:: is_external == False and "__os_" in id
    :+tags: operating_system

--- a/docs/modules/os/docs/requirements/aou_req.rst
+++ b/docs/modules/os/docs/requirements/aou_req.rst
@@ -79,5 +79,5 @@ Generic Assumptions of Use
 
    Note3: Another example is mmap_peer which would allow accessing other processes memory if wrongly used.
 
-.. needextend:: "__os_" in id
+.. needextend:: docname is not None and "__os_" in id
    :+tags: operating_system


### PR DESCRIPTION
In the new Docs-As-Code (4.3.0) needextends will now be checked if it touches external needs. This is no longer allowed. 

This PR fixes this.  