### PR TITLE
increase docs_as_code to version 4.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,7 +69,7 @@ bazel_dep(name = "rules_java", version = "8.15.1")
 #
 ###############################################################################
 bazel_dep(name = "score_tooling", version = "1.1.2")
-bazel_dep(name = "score_docs_as_code", version = "4.2.0")
+bazel_dep(name = "score_docs_as_code", version = "4.3.0")
 bazel_dep(name = "score_process", version = "1.5.4")
 
 # Due to bazels resolution strategy, the following dependency graph is created:


### PR DESCRIPTION
This pull request updates a dependency version in the `MODULE.bazel` file. The only change is upgrading the `score_docs_as_code` dependency from version 4.2.0 to 4.3.0.