### PR TITLE
fix: add dds to communication

### DIFF
--- a/docs/features/communication/index.rst
+++ b/docs/features/communication/index.rst
@@ -34,6 +34,7 @@ Communication (v0.5 beta)
    docs/**/index
    ipc/index
    some_ip_gateway/index
+   dds_gateway/index
 
 Feature flag
 ============


### PR DESCRIPTION
dds document was added, without adding it to the communication toctree