### PR TITLE
Update CODEOWNERS to reflect architecture community proxy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,8 +17,7 @@
 /docs/                                @pahmann @masc2023 @aschemmel-tech @PandaeDo
 /docs/conf.py                         @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak
 /docs/contribute/                     @eclipse-score/automotive-score-committers
-# /docs/features/                     @eclipse-score/automotive-score-technical-leads
-/docs/features/                       @antonkri @FScholPer @qor-lb @johannes-esr
+/docs/features/                       @qor-lb @arsibo
 architecture/                         @eclipse-score/automotive-score-committers
 # requirements/                       @eclipse-score/automotive-score-technical-leads
 requirements/                         @antonkri @FScholPer @qor-lb @johannes-esr
@@ -29,7 +28,7 @@ safety_planning/                      @antonkri @FScholPer @qor-lb @johannes-esr
 verification/                         @eclipse-score/automotive-score-committers
 /docs/design_decisions/*infra*        @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak
 # setting TLs until codeowners of architecture are defined
-/docs/design_decisions/*arch*         @antonkri @FScholPer @qor-lb @johannes-esr
+/docs/design_decisions/*arch*         @qor-lb @arsibo
 /docs/design_decisions/*strat*        @antonkri @FScholPer @qor-lb @johannes-esr
 /docs/glossary/                       @eclipse-score/automotive-score-committers
 /docs/introduction/                   @eclipse-score/automotive-score-committers


### PR DESCRIPTION
Attributing work products to the architecture community and reflecting proxy election from #2931