### PR TITLE
docs: improve landing page with per-section card colors

### DIFF
--- a/docs/_assets/css/custom.css
+++ b/docs/_assets/css/custom.css
@@ -15,14 +15,19 @@
  * Loaded after the score_docs_as_code bundle, so rules here win. */
 
 /* Background of the colored card header (octicon + title) on the landing pages.
- * Change the color value below to whatever you like. */
+ * Change the color value below to whatever you like.
+ *
+ * NOTE: the !important here is unavoidable. The bundled theme rule
+ * ".score-grid .sd-card-header" in score_design.css declares the header
+ * background-color with !important. An !important declaration can only be
+ * overridden by another !important declaration, so we must mirror it here. */
 html .score-grid .sd-card-header {
     background-color: #eef1f5 !important;
 }
 
 /* Title text inside the card header (the line above "^^^"). */
 html .score-grid .sd-card-header {
-    color: #1a2733 !important;       /* text color */
+    color: #1a2733;                  /* text color */
     font-size: 1.2em;                /* text size */
     font-weight: 900;                /* boldness */
     /* font-family: "Arial", sans-serif; */
@@ -67,6 +72,7 @@ html .bd-content .score-grid .sd-card .sd-card-body {
 html .bd-content .score-grid .sd-card .sd-card-body {
     color: #1a2733;                  /* text color */
     font-size: 1em;                  /* text size */
+    text-align: left;                /* left-align body text (sphinx-design centers by default) */
     /* font-family: "Arial", sans-serif; */
 }
 
@@ -116,49 +122,46 @@ html .bd-content section:has(> .score-grid) > h2 {
 
 /* ---------------------------------------------------------------------------
  * Chapter: Introduction  (.score-grid-intro)
- * Proposed color: happy lilac (vibrant).
- * A more saturated lilac than the very pale purple used by the Reference
- * Integration section, so the hero/intro card stands out clearly while the
- * two purple-ish chapters remain easy to tell apart.
+ * Proposed color: very light green.
  * ------------------------------------------------------------------------- */
 
 /* Header background (same as body). */
 html .score-grid-intro .sd-card-header {
-    background-color: #ede0fb !important;
+    background-color: #eaf7ee !important;
 }
 
 /* Card / body background. */
 html .bd-content .score-grid-intro .sd-card,
 html .bd-content .score-grid-intro .sd-card .sd-card-body {
-    background-color: #ede0fb;
+    background-color: #eaf7ee;
 }
 
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-intro .sd-card-header,
 html .score-grid-intro .sd-card-header .sd-octicon {
-    color: #36204f !important;
+    color: #1d2c22;
 }
 
 /* ---------------------------------------------------------------------------
  * Chapter: Get started with S-CORE  (.score-grid-getstarted)
- * Proposed color: very light green.
+ * Proposed color: happy lilac (vibrant).
  * ------------------------------------------------------------------------- */
 
 /* Header background (same as body). */
 html .score-grid-getstarted .sd-card-header {
-    background-color: #eaf7ee !important;
+    background-color: #ede0fb !important;
 }
 
 /* Card / body background. */
 html .bd-content .score-grid-getstarted .sd-card,
 html .bd-content .score-grid-getstarted .sd-card .sd-card-body {
-    background-color: #eaf7ee;
+    background-color: #ede0fb;
 }
 
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-getstarted .sd-card-header,
 html .score-grid-getstarted .sd-card-header .sd-octicon {
-    color: #1d2c22 !important;
+    color: #36204f;
 }
 
 /* ---------------------------------------------------------------------------
@@ -180,7 +183,7 @@ html .bd-content .score-grid-artifacts .sd-card .sd-card-body {
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-artifacts .sd-card-header,
 html .score-grid-artifacts .sd-card-header .sd-octicon {
-    color: #16292c !important;
+    color: #16292c;
 }
 
 /* ---------------------------------------------------------------------------
@@ -202,7 +205,7 @@ html .bd-content .score-grid-processes .sd-card .sd-card-body {
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-processes .sd-card-header,
 html .score-grid-processes .sd-card-header .sd-octicon {
-    color: #33291a !important;
+    color: #33291a;
 }
 
 /* ---------------------------------------------------------------------------
@@ -224,7 +227,7 @@ html .bd-content .score-grid-refintegration .sd-card .sd-card-body {
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-refintegration .sd-card-header,
 html .score-grid-refintegration .sd-card-header .sd-octicon {
-    color: #271a33 !important;
+    color: #271a33;
 }
 
 /* ---------------------------------------------------------------------------
@@ -246,5 +249,5 @@ html .bd-content .score-grid-infratooling .sd-card .sd-card-body {
 /* Title + icon: dark so they stay readable on the light header. */
 html .score-grid-infratooling .sd-card-header,
 html .score-grid-infratooling .sd-card-header .sd-octicon {
-    color: #331a1f !important;
+    color: #331a1f;
 }

--- a/docs/_assets/css/custom.css
+++ b/docs/_assets/css/custom.css
@@ -1,0 +1,250 @@
+/* *******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * ***************************************************************************** */
+
+/* Custom overrides for the S-CORE documentation.
+ * Loaded after the score_docs_as_code bundle, so rules here win. */
+
+/* Background of the colored card header (octicon + title) on the landing pages.
+ * Change the color value below to whatever you like. */
+html .score-grid .sd-card-header {
+    background-color: #eef1f5 !important;
+}
+
+/* Title text inside the card header (the line above "^^^"). */
+html .score-grid .sd-card-header {
+    color: #1a2733 !important;       /* text color */
+    font-size: 1.2em;                /* text size */
+    font-weight: 900;                /* boldness */
+    /* font-family: "Arial", sans-serif; */
+}
+
+/* Put the icon and the title on the same line.
+ * Both sit in the card header as separate paragraphs. Flex aligns them in a
+ * single row: the icon stays on the left, and the title sits right next to it. */
+html .score-grid .sd-card-header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5em;
+}
+
+/* Icon: keep its natural width, pinned to the left. */
+html .score-grid .sd-card-header .sd-octicon {
+    flex: 0 0 auto;
+}
+
+/* Title: keep it left-aligned next to the icon. */
+html .score-grid .sd-card-header p {
+    margin: 0;
+    flex: 1 1 auto;
+    text-align: left;
+}
+
+/* The octicon (icon) in the header. */
+html .score-grid .sd-card-header .sd-octicon {
+    color: #1a2733;
+}
+
+/* Background of the card body (description text area).
+ * NOTE: the pydata theme sets this via ".bd-content .sd-card .sd-card-body"
+ * (3 classes). We must match/exceed that specificity, otherwise nothing
+ * changes. The ".bd-content .sd-card" ancestors below do exactly that. */
+html .bd-content .score-grid .sd-card .sd-card-body {
+    background-color: #eef1f5;
+}
+
+/* Description text inside the card body. */
+html .bd-content .score-grid .sd-card .sd-card-body {
+    color: #1a2733;                  /* text color */
+    font-size: 1em;                  /* text size */
+    /* font-family: "Arial", sans-serif; */
+}
+
+/* Background of the whole card. */
+html .score-grid .sd-card {
+    background-color: #eef1f5;
+}
+
+/* Link text color inside the cards.
+ * The bundle sets ".score-grid a { color: #FFFFFF }", so we override it here.
+ * Covers normal, visited and hover states. */
+html .score-grid a,
+html .score-grid a:visited {
+    color: #0a5fb4;                  /* blue */
+}
+
+html .score-grid a:hover,
+html .score-grid a:hover:visited {
+    color: #0848a0;                  /* darker blue on hover */
+}
+
+/* Spacing between the landing-page subchapters.
+ * Each subchapter is a section heading followed by a ".score-grid". Adding top
+ * margin to the grid pushes each subchapter further from the previous one.
+ * Increase/decrease the value below to taste. */
+html .bd-content .score-grid {
+    margin-top: 3rem;
+}
+
+/* Size of the subchapter titles (Introduction, Get started, ...).
+ * ":has(.score-grid)" limits this to the landing-page sections that contain a
+ * grid, so headings on other pages are not affected. Lower the value to shrink. */
+html .bd-content section:has(> .score-grid) > h2 {
+    font-size: 1.5rem;
+}
+
+/* ===========================================================================
+ * Per-chapter overrides.
+ *
+ * Each landing-page chapter (grid) carries its own class via :class-container:
+ * in docs/index.rst, e.g. ":class-container: score-grid score-grid-artifacts".
+ * The per-chapter rules below are more specific than the generic ".score-grid"
+ * rules above, so they win.
+ *
+ * To restyle one chapter, edit only its block below.
+ * =========================================================================== */
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Introduction  (.score-grid-intro)
+ * Proposed color: happy lilac (vibrant).
+ * A more saturated lilac than the very pale purple used by the Reference
+ * Integration section, so the hero/intro card stands out clearly while the
+ * two purple-ish chapters remain easy to tell apart.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-intro .sd-card-header {
+    background-color: #ede0fb !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-intro .sd-card,
+html .bd-content .score-grid-intro .sd-card .sd-card-body {
+    background-color: #ede0fb;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-intro .sd-card-header,
+html .score-grid-intro .sd-card-header .sd-octicon {
+    color: #36204f !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Get started with S-CORE  (.score-grid-getstarted)
+ * Proposed color: very light green.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-getstarted .sd-card-header {
+    background-color: #eaf7ee !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-getstarted .sd-card,
+html .bd-content .score-grid-getstarted .sd-card .sd-card-body {
+    background-color: #eaf7ee;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-getstarted .sd-card-header,
+html .score-grid-getstarted .sd-card-header .sd-octicon {
+    color: #1d2c22 !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Software artifacts  (.score-grid-artifacts)
+ * Proposed color: very light cyan.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-artifacts .sd-card-header {
+    background-color: #e9f7f9 !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-artifacts .sd-card,
+html .bd-content .score-grid-artifacts .sd-card .sd-card-body {
+    background-color: #e9f7f9;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-artifacts .sd-card-header,
+html .score-grid-artifacts .sd-card-header .sd-octicon {
+    color: #16292c !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Project structure and processes  (.score-grid-processes)
+ * Proposed color: very light amber.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-processes .sd-card-header {
+    background-color: #fdf4e6 !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-processes .sd-card,
+html .bd-content .score-grid-processes .sd-card .sd-card-body {
+    background-color: #fdf4e6;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-processes .sd-card-header,
+html .score-grid-processes .sd-card-header .sd-octicon {
+    color: #33291a !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Reference Integration  (.score-grid-refintegration)
+ * Proposed color: very light purple.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-refintegration .sd-card-header {
+    background-color: #f3eefb !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-refintegration .sd-card,
+html .bd-content .score-grid-refintegration .sd-card .sd-card-body {
+    background-color: #f3eefb;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-refintegration .sd-card-header,
+html .score-grid-refintegration .sd-card-header .sd-octicon {
+    color: #271a33 !important;
+}
+
+/* ---------------------------------------------------------------------------
+ * Chapter: Infrastructure and Tooling  (.score-grid-infratooling)
+ * Proposed color: very light rose.
+ * ------------------------------------------------------------------------- */
+
+/* Header background (same as body). */
+html .score-grid-infratooling .sd-card-header {
+    background-color: #fbeef0 !important;
+}
+
+/* Card / body background. */
+html .bd-content .score-grid-infratooling .sd-card,
+html .bd-content .score-grid-infratooling .sd-card .sd-card-body {
+    background-color: #fbeef0;
+}
+
+/* Title + icon: dark so they stay readable on the light header. */
+html .score-grid-infratooling .sd-card-header,
+html .score-grid-infratooling .sd-card-header .sd-octicon {
+    color: #331a1f !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,13 @@ extensions = [
     "score_sphinx_bundle",
 ]
 
+# Serve files from docs/_assets and load our own CSS overrides last so they win
+# over the styles shipped by the score_docs_as_code bundle.
+html_static_path = ["_assets"]
+html_css_files = [
+    "css/custom.css",
+]
+
 # Hide both sidebars on the users_guide landing page (left: html_sidebars, right: secondary_sidebar_items)
 html_sidebars = {
     "users_guide/index": [],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,18 +47,23 @@ S-CORE Platform Documentation
 Introduction
 ------------
 
-Eclipse S-CORE was founded in September 2024 by automotive industry members with a shared goal:
-a code-first, open-source software platform for onboard ECUs that the whole industry can build on.
+.. grid:: 1
+   :class-container: score-grid score-grid-intro
 
-Rather than each company independently developing and maintaining a software platform — at high cost
-and without direct customer value — S-CORE provides a common foundation with:
+   .. grid-item-card::
 
-- **A reference implementation** that catches integration issues early and prevents known bugs from reappearing across projects.
-- **A Functional-Safety-compliant process** (ISO 26262) applied to all modules, making S-CORE unique among open-source automotive projects.
-- **Full transparency**: process, tooling, and CI checks are open source — any stakeholder can verify the results.
+      Eclipse S-CORE was founded in September 2024 by automotive industry members with a shared goal:
+      a code-first, open-source software platform for onboard ECUs that the whole industry can build on.
 
-**Note:** S-CORE is not a ready-to-integrate series product. It is a generic foundation for commercial distributions.
-Responsibility for ASPICE, ISO 21434 (cybersecurity), and ISO 26262 (functional safety) compliance of the final system always remains with the series project.
+      Rather than each company independently developing and maintaining a software platform — at high cost
+      and without direct customer value — S-CORE provides a common foundation with:
+
+      - **A reference implementation** that catches integration issues early and prevents known bugs from reappearing across projects.
+      - **A Functional-Safety-compliant process** (ISO 26262) applied to all modules, making S-CORE unique among open-source automotive projects.
+      - **Full transparency**: process, tooling, and CI checks are open source — any stakeholder can verify the results.
+
+      **Note:** S-CORE is not a ready-to-integrate series product. It is a generic foundation for commercial distributions.
+      Responsibility for ASPICE, ISO 21434 (cybersecurity), and ISO 26262 (functional safety) compliance of the final system always remains with the series project.
 
 
 Get started with S-CORE
@@ -66,14 +71,14 @@ Get started with S-CORE
 
 .. grid:: 3
    :gutter: 3
-   :class-container: score-grid
+   :class-container: score-grid score-grid-getstarted
 
    .. grid-item-card::
       :link: users_guide/project_basics/index
       :link-type: doc
       :text-align: center
 
-      :octicon:`book;3em`
+      :octicon:`book;1.5em`
 
       Overview
       ^^^
@@ -85,7 +90,7 @@ Get started with S-CORE
       :link-type: doc
       :text-align: center
 
-      :octicon:`code-square;3em`
+      :octicon:`code-square;1.5em`
 
       Contribute own module
       ^^^
@@ -97,85 +102,163 @@ Get started with S-CORE
       :link-type: doc
       :text-align: center
 
-      :octicon:`rocket;3em`
+      :octicon:`rocket;1.5em`
 
       What's next?
       ^^^
       Check how you can start being productive immediately
 
-Software artifacts
-------------------
+Software architecture
+---------------------
 
 .. grid:: 1 1 3 3
-   :class-container: score-grid
+   :class-container: score-grid score-grid-artifacts
 
    .. grid-item-card::
 
-      :octicon:`checklist;3em`
+      :octicon:`checklist;1.5em`
 
       Requirements
       ^^^
-      Analyze :ref:`Stakeholder <stakeholder_requirements>` requirements for
-      the work with and implementation inside S-CORE.
-      Or get the complete picture on the :ref:`requirements` page.
+      Understand the main goals of the S-CORE platform by reading the
+      :ref:`Stakeholder requirements <stakeholder_requirements>` and
+      :ref:`SW-platform Assumptions <platform_assumptions>`.
 
 
 
    .. grid-item-card::
 
-      :octicon:`package;3em`
+      :octicon:`package;1.5em`
 
       Features & Modules
       ^^^
-      :ref:`Features <features>` and :ref:`Modules <modules>` are the heart of the S-CORE software.
+      Explore the :ref:`Features <features>` and :ref:`Modules <modules>`, which are the heart of the S-CORE software.
 
    .. grid-item-card::
+      :link: https://eclipse-score.github.io/reference_integration/main/s_core_v_1/roadmap/roadmap.html
+      :link-type: url
+      :text-align: center
 
-      :octicon:`tag;3em`
+      :octicon:`milestone;1.5em`
 
-      Releases
-      ^^^
-      Check out our `latest release <https://eclipse-score.github.io/reference_integration/main/>`_
-      or explore our `release roadmap <https://eclipse-score.github.io/reference_integration/main/_collections/score_platform/docs/score_releases/index.html>`_.
+      S-CORE v1.0 Roadmap
+      ^^^^^^^^^^^^^^^^^^^
+      Follow the `S-CORE v1.0 roadmap <https://eclipse-score.github.io/reference_integration/main/s_core_v_1/roadmap/roadmap.html>`_
+      to understand upcoming milestones and planning towards the release of the **version 1.0**.
 
 
 Project structure and processes
 -------------------------------
 
 .. grid:: 1 1 3 3
-   :class-container: score-grid
+   :class-container: score-grid score-grid-processes
 
    .. grid-item-card::
 
-      :octicon:`workflow;3em`
+      :octicon:`workflow;1.5em`
 
       Process
       ^^^
-      Understand how we work, by reading our `Process description <https://eclipse-score.github.io/process_description/main/index.html>`_.
-      And receive tips & tricks for our used tool stack by reading the
-      :ref:`contribute`.
+      Check the `main idea <https://eclipse-score.github.io/process_description/main/introduction/index.html>`_
+      and `concepts <https://eclipse-score.github.io/process_description/main/general_concepts/index.html>`_
+      to understand the reasons behind our software development process.
 
    .. grid-item-card::
 
-      :octicon:`organization;3em`
+      :octicon:`list-unordered;1.5em`
+
+      Process Areas
+      ^^^
+      Check the detailed `documentation of every process area <https://eclipse-score.github.io/process_description/main/process_areas/index.html>`_,
+      which contains requirements, guidances, workflows and a list of work products for every process area in S-CORE.
+
+   .. grid-item-card::
+
+      :octicon:`organization;1.5em`
 
       Platform Management Plan (PMP)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       Read about our project and organization structure in the
-      :ref:`Project Handbook <pmp>`.
+      `Project Handbook <https://eclipse-score.github.io/score/main/platform_management_plan/project_management.html>`_.
       And learn how we deal with :ref:`Platform Safety Plan <score_platform_safety_plan>` or care about :ref:`Software Verification Plan <software_verification_plan>`.
 
+Reference Integration
+---------------------
+
+.. grid:: 1 1 3 3
+   :class-container: score-grid score-grid-refintegration
+
    .. grid-item-card::
-      :link: https://github.com/eclipse-score/reference_integration
+
+      :octicon:`git-merge;1.5em`
+
+      Integration Baseline
+      ^^^
+      Discover how all platform modules are continuously built and tested together
+      to form the authoritative `S-CORE integration baseline <https://github.com/eclipse-score/reference_integration>`_.
+      Check the `integration status <https://eclipse-score.github.io/reference_integration/main/status_dashboard.html>`_ of every module.
+
+   .. grid-item-card::
+      :link: https://eclipse-score.github.io/reference_integration/main/s_core_v_1/releases/releases.html
       :link-type: url
-      :text-align: center
 
-      :octicon:`repo;3em`
+      :octicon:`package-dependents;1.5em`
 
-      Reference Integration
-      ^^^^^^^^^^^^^^^^^^^^^
-      Explore the S-CORE reference integration — a continuously built and tested
-      assembly of all platform modules, serving as the authoritative integration baseline.
+      Releases Overview
+      ^^^
+      Browse the `release notes <https://eclipse-score.github.io/reference_integration/main/s_core_v_1/releases/releases.html>`_
+      and see the current state of the platform.
+
+   .. grid-item-card::
+      :link: https://eclipse-score.github.io/reference_integration/main/integration_process/integration_process.html
+      :link-type: url
+
+      :octicon:`iterations;1.5em`
+
+      Integration Process
+      ^^^
+      Follow the `integration process <https://eclipse-score.github.io/reference_integration/main/integration_process/integration_process.html>`_
+      to understand how platform modules are integrated together.
+
+Infrastructure and Tooling
+--------------------------
+
+.. grid:: 1 1 3 3
+   :class-container: score-grid score-grid-infratooling
+
+   .. grid-item-card::
+      :link: https://eclipse-score.github.io/infrastructure/dev/index.html
+      :link-type: url
+
+      :octicon:`tools;1.5em`
+
+      Documentation
+      ^^^
+      Get to know the S-CORE tool stack, testing and CI infrastructure.
+      Read the
+      `infra & tooling docs <https://eclipse-score.github.io/infrastructure/dev/index.html>`_.
+
+   .. grid-item-card::
+      :link: https://eclipse-score.github.io/infrastructure/dev/explanation/index.html
+      :link-type: url
+
+      :octicon:`mark-github;1.5em`
+
+      Status
+      ^^^
+      Get insights into the current state of the S-CORE tooling and infrastructure.
+      Check the status `overview <https://eclipse-score.github.io/infrastructure/dev/explanation/index.html>`_
+      to see how the build and CI components are set up and maintained.
+
+   .. grid-item-card::
+
+      :octicon:`tools;1.5em`
+
+      Toolchains
+      ^^^
+      S-CORE provides hermetic Bazel toolchains for building its modules.
+      Explore the `C++ toolchains <https://github.com/eclipse-score/bazel_cpp_toolchains>`_
+      and the `Rust toolchains <https://github.com/eclipse-score/toolchains_rust>`_ used across the platform.
 
 .. raw:: html
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,9 +58,9 @@ Introduction
       Rather than each company independently developing and maintaining a software platform — at high cost
       and without direct customer value — S-CORE provides a common foundation with:
 
-      - **A reference implementation** that catches integration issues early and prevents known bugs from reappearing across projects.
-      - **A Functional-Safety-compliant process** (ISO 26262) applied to all modules, making S-CORE unique among open-source automotive projects.
-      - **Full transparency**: process, tooling, and CI checks are open source — any stakeholder can verify the results.
+      - **A reference implementation** that catches integration issues early and prevents known bugs from reappearing across projects
+      - **A Functional-Safety-compliant process** (ISO 26262) applied to all modules, making S-CORE unique among open-source automotive projects
+      - **Full transparency**: process, tooling, and CI checks are open source — any stakeholder can verify the results
 
       **Note:** S-CORE is not a ready-to-integrate series product. It is a generic foundation for commercial distributions.
       Responsibility for ASPICE, ISO 21434 (cybersecurity), and ISO 26262 (functional safety) compliance of the final system always remains with the series project.
@@ -196,7 +196,6 @@ Reference Integration
       ^^^
       Discover how all platform modules are continuously built and tested together
       to form the authoritative `S-CORE integration baseline <https://github.com/eclipse-score/reference_integration>`_.
-      Check the `integration status <https://eclipse-score.github.io/reference_integration/main/status_dashboard.html>`_ of every module.
 
    .. grid-item-card::
       :link: https://eclipse-score.github.io/reference_integration/main/s_core_v_1/releases/releases.html
@@ -210,8 +209,6 @@ Reference Integration
       and see the current state of the platform.
 
    .. grid-item-card::
-      :link: https://eclipse-score.github.io/reference_integration/main/integration_process/integration_process.html
-      :link-type: url
 
       :octicon:`iterations;1.5em`
 
@@ -219,6 +216,9 @@ Reference Integration
       ^^^
       Follow the `integration process <https://eclipse-score.github.io/reference_integration/main/integration_process/integration_process.html>`_
       to understand how platform modules are integrated together.
+      Consult the `cross-repo metrics report <https://eclipse-score.github.io/.github/>`_
+      and the `integration status <https://eclipse-score.github.io/reference_integration/main/status_dashboard.html>`_
+      for details.
 
 Infrastructure and Tooling
 --------------------------


### PR DESCRIPTION
## What

Improves the S-CORE documentation landing page (`docs/index.rst`) by giving each chapter grid its own distinct card color.

## Changes

- Add `docs/_assets/css/custom.css` with per-chapter color overrides for the landing-page grids.
- Wire up the stylesheet in `docs/conf.py` via `html_static_path` and `html_css_files` so the overrides load last and win over the bundled styles.
- Update `docs/index.rst` grids with per-section container classes.
- The **Introduction** section now uses a vibrant lilac accent to stand out from the other sections.

## Why

Distinct colors per section make the landing page easier to scan and visually differentiate the chapters.