### PR TITLE
Remove score_releases documentation page

### DIFF
--- a/docs/score_releases/index.rst
+++ b/docs/score_releases/index.rst
@@ -1,42 +1,6 @@
-..
-   # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
-   #
-   # See the NOTICE file(s) distributed with this work for additional
-   # information regarding copyright ownership.
-   #
-   # This program and the accompanying materials are made available under the
-   # terms of the Apache License Version 2.0 which is available at
-   # https://www.apache.org/licenses/LICENSE-2.0
-   #
-   # SPDX-License-Identifier: Apache-2.0
-   # *******************************************************************************
-
 .. _releases:
 
-S-CORE Releases
-===============
+Releases and Roadmap
+====================
 
-A **Release** is a officially distributed, versioned, and deployable collection of Project artifacts intended for distribution beyond the Project Developers. It brings together the initial set of core modules, reference integrations, and supporting infrastructure needed to build. For further information about the platform releases and module releases see `release documentation <https://eclipse-score.github.io/process_description//main/process_areas/release_management/release_workproducts.html>`_ in the process description.
-
-See also the project life cycle within the `Eclipse Development Process <https://www.eclipse.org/projects/handbook/#release>`_.
-
-S-CORE Releases Overview
-========================
-
-Timeline
----------
-The current timeline for Eclipse S-CORE releases is shown below.
-
-.. image:: ./_assets/score_release_plan.drawio.svg
-   :width: 800
-   :alt: Architecture overview
-   :align: center
-
-
-For a detailed and always up-to-date planning view, see the `GitHub project <https://github.com/orgs/eclipse-score/projects/17/views/26>`_.
-
-List of S-CORE released versions
----------------------------------
-
-See `reference integration <https://eclipse-score.github.io/reference_integration/main>`_ for the list of released versions of S-CORE reference integrations, which are the main deliverables of S-CORE releases. The list includes the release version, release date, and links to the release notes, test reports, and documentation.
+Releases and roadmap are documented under the following link: `Reference Integration V1.0 <https://eclipse-score.github.io/reference_integration/main/s_core_v_1/>`_.


### PR DESCRIPTION
## Summary

Removes the `score_releases` documentation page completely from the repository.

### Changes

- Deleted `docs/score_releases/` directory (including `index.rst` and `_assets/score_release_plan.drawio.svg`)
- Removed reference from `docs/index.rst` (grid item in Documentation section and `toctree` entry)
- Removed entry from `docs/contribute/general/folder.rst`
- Removed `docs/score_releases` section from `docs/platform_management_plan/documentation_management.rst`
- Removed CODEOWNERS entries for `/docs/score_releases/`