### PR TITLE
set accepted flag for dynamic libraries

### DIFF
--- a/docs/design_decisions/DR-002-arch.md
+++ b/docs/design_decisions/DR-002-arch.md
@@ -17,9 +17,9 @@ SPDX-License-Identifier: Apache-2.0
 
 ```{dec_rec} Library Delivery Model for Platform Modules
 :id: dec_rec__arch__library_delivery_model
-:status: proposed
+:status: accepted
 :context: Architecture
-:decision: Proposal: Opt-in per module — static by default, dynamic where justified
+:decision: Opt-in per module — static by default, dynamic where justified
 ```
 
 ---


### PR DESCRIPTION
This pull request updates the design decision record for the library delivery model. The main change is to mark the proposal as accepted rather than just proposed.

Design decision status update:

* Changed the `:status:` field from `proposed` to `accepted` in `docs/design_decisions/DR-002-arch.md`, indicating that the "Opt-in per module — static by default, dynamic where justified" delivery model has been formally accepted.