### PR TITLE
feat(hash): add feat_req__baselibs__hash_library feature requirement

### DIFF
--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -235,5 +235,19 @@ Requirements
 
    The base libraries shall provide a library for parallel execution of C++ callables with thread pool management.
 
+.. feat_req:: Hash Library
+   :id: feat_req__baselibs__hash_library
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :satisfied_by: feat__baselibs[version==1]
+   :status: valid
+   :version: 1
+
+   The base libraries shall provide a hash library supporting cryptographic hash
+   calculation (e.g. SHA-256, SHA-512) and checksum algorithms (e.g. CRC-32) over
+   byte data and streams via a pluggable interface.
+
 .. needextend:: is_external == False and "__baselibs" in id
    :+tags: baselibs


### PR DESCRIPTION
Added a high-level feature requirement for the hash library to the baselibs feature requirements file. This requirement is derived from the baselibs component requirements (comp_req__hash__*) defined in the baselibs repository.