### PR TITLE
Set valid_from attribute for all features

### DIFF
--- a/docs/features/analysis-infra/logging/docs/requirements/mw-fr_logging_req.rst
+++ b/docs/features/analysis-infra/logging/docs/requirements/mw-fr_logging_req.rst
@@ -28,6 +28,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support local timestamps for each log entry.
 
@@ -40,6 +41,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support original timestamps for routed log entries.
 
@@ -52,6 +54,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support timestamp synchronization for log entries coming from different :term:`logging nodes <logging node>`.
 
@@ -64,6 +67,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging framework shall support a log level for each log entry.
 
@@ -76,6 +80,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging framework shall prioritize logs in case of resource conflicts to ensure critical logs are not lost.
 
@@ -88,6 +93,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support logging of early startup events to capture critical initialization information.
 
@@ -100,6 +106,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support :term:`logging entity identifiers<logging entity identifier>` for each log entry.
 
@@ -112,6 +119,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support filtering by :term:`log levels <Log level>`.
 
@@ -124,6 +132,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support filtering by :term:`logging entity identifiers<logging entity identifier>`.
 
@@ -136,6 +145,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall detect and report any message loss.
 
@@ -148,6 +158,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall provide mechanisms to handle message loss gracefully.
 
@@ -162,6 +173,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow context-specific :term:`log level` activation at runtime to enable fine-grained control over logging behavior.
 
@@ -174,6 +186,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support user application as log source.
 
@@ -186,6 +199,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support :term:`component` features and :term:` platform` as log sources.
 
@@ -198,6 +212,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support console as a log sink.
 
@@ -210,6 +225,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support local file system as log sink.
 
@@ -224,6 +240,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support cloud-native drives via network as log sinks.
 
@@ -236,6 +253,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support network channels, including a second dedicated Ethernet channel, as log sinks.
 
@@ -248,6 +266,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall ensure logs appear on stdout when running unit tests.
 
@@ -260,6 +279,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support logging of data to memory which survives a reboot
    cycle.
@@ -273,6 +293,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support configuration of :term:`log levels <Log level>`.
 
@@ -285,6 +306,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support configuration of the log storage device.
 
@@ -297,6 +319,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support multiple log storage devices.
 
@@ -309,6 +332,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support configurable :term:`log storage strategy`.
 
@@ -321,6 +345,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow configuration of internal buffers sizes.
 
@@ -333,6 +358,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow configuration of storage size per log file.
 
@@ -345,6 +371,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow configuration of permission settings for log access.
 
@@ -357,6 +384,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow configuration of log filters.
 
@@ -369,6 +397,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow configuration of logging entity IDs.
 
@@ -381,6 +410,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support on-demand functionality, such as enabling or disabling log storage.
 
@@ -393,6 +423,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall provide fallback configurations, such as application-wide or system-wide defaults.
 
@@ -405,6 +436,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall allow extensions for custom log types.
 
@@ -417,6 +449,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    In case of recoverable error, the logging :term:`framework` shall continue the current operations.
 
@@ -429,6 +462,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    In case of non-recoverable error, the logging :term:`framework` shall deactivate silently and set an error state reported on shutdown.
 
@@ -441,6 +475,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall ensure that user applications are not affected by logging :term:`framework` errors.
 
@@ -453,6 +488,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support QNX and Linux operating systems (encapsulated via OSAL).
 
@@ -465,6 +501,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support C++, Rust, and Python programming languages.
 
@@ -477,6 +514,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall minimize storage resource consumption.
 
@@ -489,6 +527,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall minimize communication channel resource consumption.
 
@@ -501,6 +540,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall minimize runtime resource consumption.
 
@@ -513,6 +553,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall have low impact on overall system performance.
 
@@ -525,6 +566,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall provide:term:` QoS` for handling overflows or dropping log messages.
 .. ist "rovide QoS for handling overflows or dropping log messages." doppelt zu den loos detection req.?
@@ -538,6 +580,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall be :term:`DLT` compatible.
 
@@ -552,6 +595,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall ensure that only authorized users can access log files.
 
@@ -564,6 +608,7 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall support the ASIL level of the user function to ensure compliance with the safety requirements of the application.
 
@@ -578,5 +623,6 @@ Requirements
    :satisfied_by: feat__logging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The logging :term:`framework` shall be classified according to the overall system's safety concept if logging information is part of the verification strategy.

--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -32,6 +32,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall include core software utilities and common infrastructure components needed by multiple platform modules.
@@ -45,6 +46,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall implement functionality necessary to support safety-relevant platform components up to ASIL-B for selected functionalities.
@@ -58,6 +60,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide APIs for C++, Rust, or both, depending on the requirements of consuming platform components.
@@ -71,6 +74,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide consistent APIs while respecting language-specific idioms.
@@ -84,6 +88,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall be designed for maintainability and code reuse.
@@ -97,6 +102,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall adhere to secure coding standards to prevent vulnerabilities across platform components.
@@ -110,6 +116,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide a JSON-Library with parsing functionality.
@@ -141,6 +148,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide error handling mechanisms that enable development without relying on C++ exceptions.
@@ -154,6 +162,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The base libraries shall provide error handling mechanisms that enable development without relying on Rust panics.
    Where an idiomatic interface requires panics, an additional non-panicking option shall be provided as well.
@@ -167,6 +176,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide a container library offering additional container types not present in the C++ standard library.
@@ -180,6 +190,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The base libraries shall provide a library of containers that can serve as the basis for ABI-compatible container data structures.
 
@@ -192,6 +203,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide bit manipulation utilities for low-level operations on integral types.
@@ -205,6 +217,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide a filesystem library with file and directory manipulation functionality.
@@ -218,6 +231,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The baselibs shall provide a memory management library that includes utilities for shared memory operations, polymorphic memory resources, position-independent pointers, endianness conversion, and inter-process synchronization mechanisms.
@@ -231,6 +245,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide a library for parallel execution of C++ callables with thread pool management.
@@ -244,6 +259,7 @@ Requirements
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The base libraries shall provide a hash library supporting cryptographic hash
    calculation (e.g. SHA-256, SHA-512) and checksum algorithms (e.g. CRC-32) over

--- a/docs/features/communication/docs/requirements/index.rst
+++ b/docs/features/communication/docs/requirements/index.rst
@@ -34,6 +34,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide API to support a time-based architecture.
 
@@ -46,6 +47,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide API to support a data-driven architecture.
 
@@ -58,6 +60,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide API to support a request-driven architecture.
 
@@ -70,6 +73,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A communication interface consists of a combination of any number of the following elements:
 
@@ -86,6 +90,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    An event-type is part of a communication interface and has:
 
@@ -104,6 +109,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A method is part of a communication interface and has:
 
@@ -126,6 +132,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A signal is part of a communication interface and has:
 
@@ -150,6 +157,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Communication shall be cached based on the producer-consumer pattern.
 
@@ -162,6 +170,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Multiple service instances shall be able to offer the same interface.
 
@@ -177,6 +186,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A service instance is offered under one or more unique names by which it can be discovered.
    Names follow a POSIX path style.
@@ -194,6 +204,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support versioning of service instances:
 
@@ -212,6 +223,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The interface to access service instances is agnostic to the binding used to communicate with the service.
 
@@ -227,6 +239,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support stateless communication.
 
@@ -243,6 +256,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support multiple service instances per software architecture element.
 
@@ -258,6 +272,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide service discovery to find available services during runtime. Service discovery shall consider version compatibility. Service discovery shall be handled implicitly (where possible).
 
@@ -277,6 +292,7 @@ Mixed-Criticality safety systems
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support safe communication involving communication partners on the same or multiple
    criticality levels.
@@ -290,6 +306,7 @@ Mixed-Criticality safety systems
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Consumers with lower criticality shall not be able to corrupt data consumed by partners with higher criticality.
 
@@ -302,6 +319,7 @@ Mixed-Criticality safety systems
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Consumers with lower criticality shall not be able to modify the order of data consumed by partners with higher
    criticality.
@@ -315,6 +333,7 @@ Mixed-Criticality safety systems
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Consumers with lower criticality shall not be able to duplicate data consumed by other communication partners with
    higher criticality.
@@ -328,6 +347,7 @@ Mixed-Criticality safety systems
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Consumers with lower criticality shall not be able to drop data before it is consumed by partners with higher
    criticality.
@@ -345,6 +365,7 @@ Performance
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall enable Zero-Copy communication without copying to-be-transferred data.
 
@@ -363,6 +384,7 @@ User friendly API for information exchange
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide a public API for each supported programming language of S-CORE.
 
@@ -375,6 +397,7 @@ User friendly API for information exchange
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Each public API shall support the idioms of the programming language it is written in.
 
@@ -387,6 +410,7 @@ User friendly API for information exchange
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Each public API shall use core infrastructure of its programming language and accompanying standard libraries,
    whenever possible and meaningful.
@@ -406,6 +430,7 @@ Full testability for the user facing API
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The public API shall be fully mockable.
 
@@ -418,6 +443,7 @@ Full testability for the user facing API
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide a fake binding.
 
@@ -434,6 +460,7 @@ Multi-binding support
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support multiple bindings.
 
@@ -449,6 +476,7 @@ Multi-binding support
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The public API of the communication framework shall be binding-agnostic.
 
@@ -464,6 +492,7 @@ Multi-binding support
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The association of a service instance and the appropriate binding shall be specified in the deployment configuration.
 
@@ -653,6 +682,7 @@ Dynamic deployment at runtime
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Deployment configuration shall be read from an integrity-checked configuration file at runtime.
 
@@ -668,6 +698,7 @@ Tracing
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall provide infrastructure to enable binding-agnostic, zero-copy, read-only tracing of
    communication.
@@ -684,6 +715,7 @@ Security Impact
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support an Access Control Lists in the deployment configuration.
 
@@ -696,6 +728,7 @@ Security Impact
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support an Access Control List per service instance.
 
@@ -708,6 +741,7 @@ Security Impact
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support an Access Control List for the communication partner offering a service
    instance (producer).
@@ -722,6 +756,7 @@ Security Impact
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support an Access Control List for the communication partner consuming a service
    instance.
@@ -739,6 +774,7 @@ Safety Impact
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The communication framework shall support safe communication up to ASIL-B.
 

--- a/docs/features/communication/ipc/docs/requirements/index.rst
+++ b/docs/features/communication/ipc/docs/requirements/index.rst
@@ -34,6 +34,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    IPC communication shall be possible without copying to-be-transferred data.
 
@@ -46,6 +47,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The IPC binding shall ensure confidentiality of its communication.
 
@@ -58,6 +60,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The IPC binding shall ensure integrity of its communication.
 
@@ -70,6 +73,7 @@ Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
    criticality level.

--- a/docs/features/communication/some_ip_gateway/requirements/index.rst
+++ b/docs/features/communication/some_ip_gateway/requirements/index.rst
@@ -28,6 +28,7 @@ Functional Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SOME/IP Gateway shall support an interface to plug-in a SOME/IP stack implementation.
 
@@ -40,6 +41,7 @@ Functional Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SOME/IP Gateway shall support an interface to plug-in a E2E protection service implementation.
 
@@ -52,6 +54,7 @@ Functional Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SOME/IP protocol implementation shall be fully compatible and complying with the SOME/IP protocol specification from `Open SOME/IP <https://github.com/some-ip-com/open-someip-spec>`_.
 
@@ -64,6 +67,7 @@ Functional Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The E2E protection implementation shall be fully compatible and complying with the E2E protocol specification from `some-ip.com <https://some-ip.com/>`_.
 
@@ -76,5 +80,6 @@ Functional Requirements
    :satisfied_by: feat__com_communication[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Service Discovery implementation shall be fully compatible and complying with the SOME/IP service discovery specification from `Open SOME/IP <https://github.com/some-ip-com/open-someip-spec>`_.

--- a/docs/features/configuration/config_mgmt/requirements/index.rst
+++ b/docs/features/configuration/config_mgmt/requirements/index.rst
@@ -26,6 +26,7 @@ Terms and definitions
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    An individual vehicle configuration property used for vehicle specific adaptations is called ``Parameter``.
 
@@ -37,6 +38,7 @@ Terms and definitions
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Group of Parameters which belong to the same functionality and share an integrity protection is called ``Parameter Set``.
 
@@ -51,6 +53,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Configuration Management shall provide a central housekeeping for Parameters.
 
@@ -62,6 +65,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Every Parameter shall be contained in exactly one Parameter Set.
 
@@ -73,6 +77,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Parameters names shall be unique for an ECU project.
 
@@ -84,6 +89,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Parameters Set names shall be unique for an ECU project.
 
@@ -95,6 +101,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Parameter Set configuration shall contain a mapping of Parameters to Parameter Sets, Parameter names and default values.
 
@@ -106,6 +113,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Parameter Set configuration shall be determined solely by a read-only input source, deployed on the target.
 
@@ -117,6 +125,7 @@ Data Housekeeping
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Parameter values shall be modifiable during runtime regarding modification procedure specific for a parameter kind.
 
@@ -131,6 +140,7 @@ Parameter Provision
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    Configuration Management shall provide a generic interface, independent of any Parameter definitions, for applications to access Parameters in read-only mode.
 
@@ -142,6 +152,7 @@ Parameter Provision
    :derived_from: stkh_req__functional_req__file_based[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A Parameter Set shall be accessible via interface using a key-value principle, where user application passes a Parameter Set name to the interface and its value is returned as result.
 
@@ -156,6 +167,7 @@ Parameter Qualification
    :derived_from: stkh_req__functional_req__safe_config[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A Parameter Set shall contain a qualifier to indicate its integrity.
 
@@ -167,5 +179,6 @@ Parameter Qualification
    :derived_from: stkh_req__functional_req__safe_config[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    There shall exist an overall qualifier for all Parameter Sets to indicate the state of integrity checks at the point of time of initial provision of parameters.

--- a/docs/features/lifecycle/requirements/index.rst
+++ b/docs/features/lifecycle/requirements/index.rst
@@ -26,6 +26,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching :term:`Processes <Process>`.
 
@@ -37,6 +38,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for ordering the launching of
     :term:`Processes <Process>` based on the dependencies.
@@ -50,6 +52,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching :term:`Processes <Process>`
     in parallel.
@@ -62,6 +65,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to wait for configurable custom
     conditions, which can be signaled from applications via :term:`Control Interface`.
@@ -75,6 +79,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to pass the output of one or
     multiple :term:`Processes <Process>` as input arguments to another process.
@@ -87,6 +92,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given set of arguments.
@@ -99,6 +105,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching process with a
     given set of debug arguments in debug mode.
@@ -111,6 +118,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process in a state
     waiting for a debugger connection.
@@ -124,6 +132,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given :term:`UID`/:term:`GID` (user name/Group Identifier).
@@ -136,6 +145,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given priority.
@@ -149,6 +159,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given :term:`Working Directory`.
@@ -161,6 +172,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a terminal or a
     session leader.
@@ -173,6 +185,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for stdin, stdout, stderr
     redirection.
@@ -185,6 +198,7 @@ Launching Processes
     :derived_from: stkh_req__dependability__safety_features_4[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to be started with security
     policy as non-root.
@@ -197,6 +211,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support a configurable amount of retries in
     case error occurs during startup of a component (e.g. file not available) occurs.
@@ -209,6 +224,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching :term:`Processes <Process>`
     with configured OS-specific capabilities and privileges.
@@ -221,6 +237,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with
     given :term:`File Descriptor` inheritance restrictions.
@@ -234,6 +251,7 @@ Launching Processes
     :derived_from: stkh_req__dependability__safety_features_4[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given security policy.
@@ -246,6 +264,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given set of supplementary groups.
@@ -258,6 +277,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with
     certain scheduling policy.
@@ -270,6 +290,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given runmask.
@@ -283,6 +304,7 @@ Launching Processes
     :derived_from: stkh_req__dependability__security_features[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching process with
     :term:`ASLR` (Address Space Layout Randomization).
@@ -295,6 +317,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process with a
     given set of system resource limits (rlimit).
@@ -308,6 +331,7 @@ Launching Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for launching a process to
     detach from parent.
@@ -323,6 +347,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide launching processes based on conditions.
 
@@ -334,6 +359,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to conditionally start a process
     or process group based on the return value of a single or multiple :term:`Processes <Process>`
@@ -347,6 +373,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for per condition configurable
     total wait time for launch conditions to be satisfied.
@@ -359,6 +386,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for per condition configurable
     :term:`Polling Interval` for launch conditions to be checked.
@@ -371,6 +399,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall be able to validate the pre-start conditions of the executable using the conditions.
 
@@ -382,6 +411,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall be able to validate the start of the executable using the conditions.
 
@@ -393,6 +423,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a way to store the status of the launched process.
 
@@ -404,6 +435,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a method for condition check based on process state.
 
@@ -415,6 +447,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a way to configure actions based on condition evaluation i.e. to be able to configure SUCCESS and FAILURE case.
 
@@ -426,6 +459,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a method for condition check for a path.
 
@@ -437,6 +471,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a method for condition check for environment variable.
 
@@ -448,6 +483,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a method to check if all dependencies have been executed.
 
@@ -459,6 +495,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a method to check if at least one dependency has been executed.
 
@@ -470,6 +507,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a way to define for each :term:`SWC` (Software Components), its dependencies.
 
@@ -481,6 +519,7 @@ Conditional Launching
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall provide a way to define the stop sequence for each :term:`SWC` (Software Components).
 
@@ -495,6 +534,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to adopt already running :term:`Processes <Process>`.
 
@@ -506,6 +546,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to dropping all surveillance
     and failure reaction activities of :term:`Processes <Process>`.
@@ -519,6 +560,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall permit an executable to be launched more than once.
 
@@ -531,6 +573,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall reject an inconsistent definition of set of executables dependencies.
 
@@ -543,6 +586,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall be able to stop a process when all it's dependents are stopped if specified in the set of executables.
 
@@ -555,6 +599,7 @@ Process Management
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall permit the stop order of non-dependent processes to be specified.
 
@@ -565,6 +610,7 @@ Process Management
     :safety: ASIL_B
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
     :derived_from: stkh_req__overall_goals__enable_cooperation[version==1]
 
     The Launch Manager shall be compliant to the `OCI Specification v1.2.0 <https://github.com/opencontainers/runtime-spec/releases/tag/v1.2.0>`__.
@@ -581,6 +627,7 @@ Run targets
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for :term:`run targets <Run target>` to define
     collections of :term:`Processes <Process>` that can be launched together.
@@ -593,6 +640,7 @@ Run targets
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to start a named :term:`Run target`.
 
@@ -604,6 +652,7 @@ Run targets
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to switch between different :term:`run targets <Run target>`.
 
@@ -615,6 +664,7 @@ Run targets
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall have a means for the launched :term:`Processes <Process>`
     to communicate a state, which represents the launched processes' internal state,
@@ -632,6 +682,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for configurable timeout
     :term:`Interval` to wait for the process to be stopped.
@@ -644,6 +695,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for terminating :term:`Processes <Process>`.
 
@@ -655,6 +707,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall terminate the :term:`Processes <Process>` based on the
     dependency order.
@@ -668,6 +721,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The time to wait, before SIGKILL is sent shall be configurable. In case "0" is
     stated, the SIGKILL shall be sent immediately.
@@ -680,6 +734,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support normal shutdown by terminating all
     process in the dependency order.
@@ -693,6 +748,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support slow shutdown by terminating the
     :term:`Processes <Process>` in the dependency order.
@@ -705,6 +761,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support fast shutdown by terminating itself
     without affecting the started :term:`Processes <Process>`.
@@ -717,6 +774,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall exit after performing shutdown operation by
     stopping all the :term:`Processes <Process>` it owns in the dependency order when requested.
@@ -729,6 +787,7 @@ Terminating Processes
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall implement a shutdown by sending a SIGTERM to
     the process. In case the process does not terminate itself, a SIGKILL shall be sent.
@@ -745,6 +804,7 @@ Control Interface
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for commands to control
     component states.
@@ -757,6 +817,7 @@ Control Interface
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for commands to query component
     states.
@@ -770,6 +831,7 @@ Control Interface
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to report status on components via the
     :term:`Control Interface`.
@@ -784,6 +846,7 @@ Control Interface
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to start a named :term:`Run target` respecting the
     dependencies when requested.
@@ -800,6 +863,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for monitoring abnormal
     termination of :term:`Processes <Process>`.
@@ -812,6 +876,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for external monitors to get
     notified on process life status.
@@ -825,6 +890,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support :term:`Recovery Action` for the
     abnormally terminated :term:`Processes <Process>`.
@@ -837,6 +903,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support switching to a different :term:`Run target` as
     recovery action in case a single process terminated abnormally or lost its
@@ -850,6 +917,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support a smart :term:`Watchdog`, configurable
     per process.
@@ -863,6 +931,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for configurable wait time
     that shall elapse before repeating :term:`Recovery Action`.
@@ -875,6 +944,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for monitoring adopted
     :term:`Processes <Process>`.
@@ -887,6 +957,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to detect and react to failure of the
     process launch.
@@ -899,6 +970,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to detect and react to loss of
     :term:`Liveliness` of the :term:`Processes <Process>` it owns.
@@ -911,6 +983,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall monitor the state of the :term:`Processes <Process>` as
     specified by the set of executables.
@@ -924,6 +997,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to react to a process failure by
     optionally performing one of relaunching the process, stopping the process,
@@ -938,6 +1012,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall be able to run in multiple instances with its
     own configurations on a system.
@@ -950,6 +1025,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall implement time based cyclical monitoring of itself.
 
@@ -961,6 +1037,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall trigger a notification to an external
     :term:`Watchdog` for each successful self monitoring test execution.
@@ -973,6 +1050,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall not trigger an external :term:`Watchdog`
     notification if an internal health check failed.
@@ -985,6 +1063,7 @@ Monitoring, Notification and Recovery
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support configuring the :term:`Interval` of
     the internal health check executions.
@@ -1000,6 +1079,7 @@ Logging
     :derived_from: stkh_req__dev_experience__logging_support[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall support OS specific logging facilities to analyze the early
     boot sequence.
@@ -1012,6 +1092,7 @@ Logging
     :derived_from: stkh_req__dev_experience__logging_support[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for logging process launches,
     :term:`Processes <Process>` exit/recovery, internal tasks, and interaction with external monitor.
@@ -1024,6 +1105,7 @@ Logging
     :derived_from: stkh_req__dev_experience__logging_support[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` logs shall contain timestamp information.
 
@@ -1036,6 +1118,7 @@ Logging
     :derived_from: stkh_req__dev_experience__logging_support[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide the possibility to log the :term:`DAG`
     in a human readable format, triggered via :term:`Control Interface`.
@@ -1049,6 +1132,7 @@ Logging
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall have the means to log the current dependencies in a format that can be visualized when requested.
 
@@ -1063,6 +1147,7 @@ Configuration file
     :derived_from: stkh_req__functional_req__file_based[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The launch manager shall provide modular configuration file support to configure process attributes.
 
@@ -1074,6 +1159,7 @@ Configuration file
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The launch manager shall provide modular configuration files support for configurations coming from `OCI runtime configuration<https://github.com/opencontainers/runtime-spec/blob/v1.2.0/config.md>`.
 
@@ -1086,6 +1172,7 @@ Configuration file
     :derived_from: stkh_req__functional_req__file_based[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support for extending already running
     session with additional new configuration file.
@@ -1098,6 +1185,7 @@ Configuration file
     :derived_from: stkh_req__functional_req__file_based[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The :term:`Launch Manager` shall provide support to clustering set of components
     as modules.
@@ -1111,6 +1199,7 @@ Configuration file
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall be able to centrally define defaults for specific properties for the set of executables.
 
@@ -1123,6 +1212,7 @@ Configuration file
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall check availability of executables in the filesystem only when the executable shall required to be executed.
 
@@ -1135,6 +1225,7 @@ Configuration file
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall have the means to generate the specified dependencies in a format that can be visualized.
 
@@ -1147,5 +1238,6 @@ Configuration file
     :derived_from: stkh_req__execution_model__processes[version==1]
     :status: invalid
     :version: 1
+    :valid_from: v1.0.0
 
     The Launch Manager shall have a means to validate the configuration offline.

--- a/docs/features/persistency/requirements/index.rst
+++ b/docs/features/persistency/requirements/index.rst
@@ -35,6 +35,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall provide native API support for both C++ and Rust programming languages.
 
@@ -47,6 +48,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall be operating system agnostic.
 
@@ -59,6 +61,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall ensure compatibility across different SW versions.
 
@@ -71,6 +74,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall not allocate dynamic memory during runtime. All required dynamic memory shall be allocated during initialization.
 
@@ -88,6 +92,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support multiple independent storages per application.
 
@@ -100,6 +105,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall prevent access to a single KVS instance from multiple OS processes.
 
@@ -115,6 +121,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall ensure that only authorized applications can access individual data stores.
 
@@ -131,6 +138,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: config
 
    The Persistency shall support configuration via a configuration file.
@@ -164,6 +172,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support UTF-8 encoded strings as valid key types.
 
@@ -176,6 +185,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :tags: persistency
 
    The Persistency shall support storing both primitive and non-primitive (composite) datatypes as values.
@@ -189,6 +199,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support predefined default values for keys.
 
@@ -201,6 +212,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support import of default values using an external file.
 
@@ -217,6 +229,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support retrieval of the default value associated with a key.
 
@@ -229,6 +242,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support reset of individual key or all keys to their default values.
    This is only applicable for existing keys that have a predefined default value.
@@ -242,6 +256,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support storing of key-value pairs to persistent storage.
 
@@ -254,6 +269,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall ensure that write operations are reset resistant to prevent data corruption in case of expected or unexpected interruption.
 
@@ -270,6 +286,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall recover to a consistent state after reset.
 
@@ -285,6 +302,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support atomic write operation for entire storage to ensure data consistency.
 
@@ -302,6 +320,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall minimize the write amplification during data storage operations to enhance performance and prolong the lifespan of the underlying storage medium.
 
@@ -318,6 +337,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support loading of key-value pairs from persistent storage.
 
@@ -330,6 +350,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support caching mechanisms to improve access times for frequently accessed key-value pairs.
 
@@ -342,6 +363,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support direct access to key-value pairs without the necessity to load the entire storage to RAM in advance.
 
@@ -357,6 +379,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall detect and report data integrity issues.
 
@@ -369,6 +392,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support confidential storage of key-value pairs using encryption mechanisms.
 
@@ -384,6 +408,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support multiple storage backends.
    More than one storage backend of the same type shall be optionally supported for the sake of redundancy.
@@ -402,6 +427,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall provide an asynchronous API for time consuming operations like loading and storing of data.
 
@@ -414,6 +440,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall provide a mechanism to signal the completion of an asynchronous operations to the application.
 
@@ -426,6 +453,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support explicit creation of snapshots. Snapshots are identified by unique IDs.
    Snapshots shall also include the version of the data layout. See :need:`feat_req__persistency__versioning`.
@@ -443,6 +471,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support explicit restoration of snapshots.
 
@@ -455,6 +484,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support explicit removal of snapshots.
 
@@ -467,6 +497,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support concurrent access to key-value pairs from multiple threads within the same process.
 
@@ -479,6 +510,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support versioning for different data representation of KVS.
 
@@ -495,6 +527,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall implement mechanisms to upgrade from one version to another, including multi-version jumps.
 
@@ -507,6 +540,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall ensure that random read access for key-value pair is completed with constant or logarithmic time complexity relative to the number of stored key-value pairs.
 
@@ -519,6 +553,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall provide tooling support for:
 
@@ -534,6 +569,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support the development mode.
    The development mode shall allow unrestricted data access and bypass security policies.
@@ -547,6 +583,7 @@ Requirements
    :satisfied_by: feat__persistency[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The Persistency shall support the production mode.
    The production mode should enforce the most restrictive data access controls feasible.

--- a/docs/features/security_crypto/requirements/index.rst
+++ b/docs/features/security_crypto/requirements/index.rst
@@ -28,6 +28,7 @@ Symmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality for symmetric encryption and decryption.
 
@@ -39,6 +40,7 @@ Symmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the AES-CBC symmetric encryption algorithm.
 
@@ -50,6 +52,7 @@ Symmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the AES-GCM symmetric encryption algorithm.
 
@@ -61,6 +64,7 @@ Symmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the AES-CCM symmetric encryption algorithm.
 
@@ -72,6 +76,7 @@ Symmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the ChaCha20-Poly1305 symmetric encryption algorithm.
 
@@ -86,6 +91,7 @@ Asymmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality for asymmetric encryption and decryption.
 
@@ -97,6 +103,7 @@ Asymmetric Encryption
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the ECDH algorithm for key exchange.
 
@@ -112,6 +119,7 @@ Digital Signatures
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality to create digital signatures.
 
@@ -123,6 +131,7 @@ Digital Signatures
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality to verify digital signatures.
 
@@ -134,6 +143,7 @@ Digital Signatures
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the ECDSA algorithm for digital signatures.
 
@@ -148,6 +158,7 @@ Message Authentication Code (MAC)
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality for Message Authentication Codes (MAC) to
    ensure message integrity and authenticity.
@@ -163,6 +174,7 @@ Hashing
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide hashing functionality.
 
@@ -174,6 +186,7 @@ Hashing
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the SHA-2 hashing algorithm.
 
@@ -185,6 +198,7 @@ Hashing
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the SHA-3 hashing algorithm.
 
@@ -199,6 +213,7 @@ Key Derivation Functions (KDF)
    :safety: QM
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
    :derived_from: stkh_req__dependability__security_features[version==1]
 
    The security component shall provide Key Derivation Functions (KDFs) to derive one or more
@@ -215,6 +230,7 @@ Random Number Generation
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide a source of entropy for random number generation.
 
@@ -226,6 +242,7 @@ Random Number Generation
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall use the ChaCha20Rng algorithm for random number generation.
 
@@ -240,6 +257,7 @@ Certificate Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide functionality to manage a set of signed and verified
    (trusted) certificates.
@@ -255,6 +273,7 @@ Key Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the secure generation of key material.
 
@@ -266,6 +285,7 @@ Key Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the secure import of key material.
 
@@ -277,6 +297,7 @@ Key Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the secure storage of key material.
 
@@ -288,6 +309,7 @@ Key Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the secure deletion of key material.
 
@@ -299,6 +321,7 @@ Key Management
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The API of the security component shall allow a selection of the available
    algorithms based on their unique name.
@@ -326,6 +349,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall use a uniform and unambiguous naming scheme for cryptographic
    algorithms.
@@ -338,6 +362,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The API of the security component shall not reveal key material to its users.
 
@@ -349,6 +374,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall be designed to mitigate side-channel and timing attacks.
 
@@ -360,6 +386,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component API shall provide clear mechanisms for initialization, context management
     (request, reuse, release), and de-initialization of cryptographic resources.
@@ -372,6 +399,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide a structured and consistent mechanism for error reporting
    and logging.
@@ -384,6 +412,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A security concept shall be created for the security component, including security goals,
    plausible attacks, critical failures, and countermeasures.
@@ -396,6 +425,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall allow the updating of its cryptographic algorithms.
 
@@ -407,6 +437,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall withstand reverse engineering of its secrets.
 
@@ -418,6 +449,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall consider the production scenario where initial production keys are
    brought into the system.
@@ -430,6 +462,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall be designed to be ready for post-quantum cryptography.
 
@@ -441,6 +474,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall be able to rely on hardware acceleration for cryptographic
    operations.
@@ -453,6 +487,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    A software-only solution for cryptographic operations shall be available as a fallback.
 
@@ -464,6 +499,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall have access to a trusted real-world wall clock.
 
@@ -475,6 +511,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall use system-level means (e.g., co-processor, HSM, TEE) to protect
    its memory and CPU from applications and the normal operating system.
@@ -487,6 +524,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support roles and capability rights management to enforce access
    control to cryptographic functions and key material.
@@ -499,6 +537,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall provide a mechanism to report potential security anomalies or
    threats to an Intrusion Detection System (IDS).
@@ -511,6 +550,7 @@ Non-Functional Requirements
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall incorporate measures to mitigate the risk of Denial-of-Service
    (DoS) attacks that could be caused by malicious messages creating exceptional computational
@@ -527,6 +567,7 @@ Secure Communication Protocols
    :derived_from: stkh_req__dependability__security_features[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The security component shall support the Transport Layer Security (TLS) 1.3 protocol for secure
    communication over Ethernet.

--- a/docs/features/time/docs/requirements/index.rst
+++ b/docs/features/time/docs/requirements/index.rst
@@ -26,6 +26,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_sync[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall synchronize the local clock with an external **Time Master** using the gPTP protocol (IEEE 802.1AS).
 
@@ -37,6 +38,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_sync[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall synchronize the local time, see feat_req__time__vehicle_time__sync, base with **Time Master** within a defined
    precision, based on the system setup.
@@ -56,6 +58,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to access the synchronized vehicle time.
 
@@ -67,6 +70,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read the accuracy qualifier of the local synchronized time base.
 
@@ -84,6 +88,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read the time point qualifier of the local synchronized time base.
 
@@ -97,6 +102,7 @@ Time Synchronization
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an access its data via specified APIs in a fast and very efficient manner,
    avoiding, if possible, kernel calls, resource manager involvement and so on.
@@ -117,6 +123,7 @@ Time Synchronization
    :derived_from: stkh_req__dev_experience__debugging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide a mechanism to log the internal state of the synchronization process,
    to be able to debug and diagnose the synchronization process.
@@ -134,6 +141,7 @@ Time Synchronization to absolute external sources
    :derived_from: stkh_req__time__absolute_time_sync[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall support synchronization with external time sources, such as UTC time from GPS.
 
@@ -145,6 +153,7 @@ Time Synchronization to absolute external sources
    :derived_from: stkh_req__time__absolute_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read the absolute time base, synchronized to external time sources.
 
@@ -156,6 +165,7 @@ Time Synchronization to absolute external sources
    :derived_from: stkh_req__time__absolute_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read accuracy qualifier of the absolute time base, synchronized to external time sources.
 
@@ -182,6 +192,7 @@ Time Synchronization to absolute external sources
    :derived_from: stkh_req__time__absolute_time_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read security qualifier of the absolute time base, synchronized to external time sources.
 
@@ -200,6 +211,7 @@ Time Synchronization to absolute external sources
    :derived_from: stkh_req__dev_experience__debugging[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide a mechanism to log the internal state of the absolute time synchronization process,
    to be able to debug and diagnose the synchronization process.
@@ -215,6 +227,7 @@ Local Clock
    :derived_from: stkh_req__time__high_precision_clock_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read the high precision clock in nanoseconds precision.
 
@@ -230,6 +243,7 @@ Local Clock
    :derived_from: stkh_req__time__monotonic_clock_api[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide an API to read monotonic, not adjustable clock value.
 
@@ -244,6 +258,7 @@ Testability
    :derived_from: stkh_req__dev_experience__mockup_public_apis[version==1]
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The **score::time feature** shall provide support for mocking its public interfaces, enabling unit,
    component and integration testing of applications.

--- a/docs/requirements/stakeholder/index.rst
+++ b/docs/requirements/stakeholder/index.rst
@@ -36,6 +36,7 @@ Overall goals
    :rationale: This is a usability constraint needed for long maintenance support
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall enable the reuse of application software via a set of managed APIs.
    These APIs shall be developed via a well-defined life-cycle ensuring
@@ -50,6 +51,7 @@ Overall goals
     :rationale: To enable cooperation with other cooperation partners.
     :status: valid
     :version: 1
+    :valid_from: v1.0.0
 
     The SW-platform shall where possible be based on existing standards (e.g. network protocols).
 
@@ -61,6 +63,7 @@ Overall goals
     :rationale: tbd
     :status: valid
     :version: 1
+    :valid_from: v1.0.0
 
     The SW-platform shall provide variant management support.
     Variant management support shall enable users to ensure the
@@ -94,6 +97,7 @@ Functional requirements
    :rationale: File based configuration allows changes without rebuilding the software.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support configuration of applications via files (e.g. yaml, json)
 
@@ -106,6 +110,7 @@ Functional requirements
    :status: valid
    :version: 1
    :tags: safety_mechanism
+   :valid_from: v1.0.0
 
    The SW-platform shall provide towards the applications a safe key/value store.
 
@@ -120,6 +125,7 @@ Functional requirements
    :status: valid
    :version: 1
    :tags: safety_mechanism
+   :valid_from: v1.0.0
 
    The SW-platform shall support safe configuration.
 
@@ -134,6 +140,7 @@ Functional requirements
    :rationale: Safe systems require computations to be done in safe environments.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support safe computation.
 
@@ -148,6 +155,7 @@ Functional requirements
    :rationale: Common libraries reduce duplication, improve consistency and quality across components.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide a set of base libraries offering common functionality for SW-platform components.
 
@@ -172,6 +180,7 @@ Functional requirements
    :rationale: Applications typically need to store data across power cycles.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support to store data on non-volatile memory e.g. disks, flash, etc.
 
@@ -184,6 +193,7 @@ Functional requirements
    :rationale: This allows portability of SW-platform on POSIX compliant operating systems.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support operating systems compliant with IEEE Std 1003.1 (2004 Edition or newer)
 
@@ -260,6 +270,7 @@ Dependability
    :rationale: The SW-platform shall be usable by safety relevant applications.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support applications with an automotive safety
    integrity level up to ASIL-B.
@@ -519,6 +530,7 @@ Dependability
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the development of highly available systems.
    (see also `Availability <https://en.wikipedia.org/wiki/Availability>`_).
@@ -532,6 +544,7 @@ Dependability
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the following security features:
 
@@ -590,6 +603,7 @@ interaction)** — each emphasize different operational priorities.
    :status: valid
    :version: 1
    :tags: safety_mechanism
+   :valid_from: v1.0.0
 
    The SW-platform shall support a deterministic, time-based application execution model that triggers logic based on predefined schedules or
    polling intervals.
@@ -603,6 +617,7 @@ interaction)** — each emphasize different operational priorities.
    :rationale: tbd - potentially above explanation
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support an event-driven, high-throughput application architecture where execution is triggered by data changes.
 
@@ -614,6 +629,7 @@ interaction)** — each emphasize different operational priorities.
    :rationale: tbd - potentially above explanation
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support a request-driven, asynchronous application architecture that processes requests on-demand.
 
@@ -630,6 +646,7 @@ Execution model
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the following scheduling strategies:
 
@@ -654,6 +671,7 @@ Execution model
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support cycle times of less then 5 ms on application level
    if this is supported by the underlying hardware.
@@ -704,6 +722,7 @@ Communication
    :rationale: Application software typically consists of multiple processes which need to interact.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support inter-process communication.
 
@@ -715,6 +734,7 @@ Communication
    :rationale: ABI compatiblity ensures that the same memory location is correctly interpreted by different programming languages.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support ABI compatible data types for zero-copy communication between Rust and C++ applications.
 
@@ -726,6 +746,7 @@ Communication
    :rationale: Application software typically maps software building blocks into the same process.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support intra-process communication.
 
@@ -749,6 +770,7 @@ Communication
    :rationale: ECUs need to interact with each other. There are multiple protocols today and more to come in the future.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support external communication via well established protocols e.g. Zenoh, DDS.
 
@@ -762,6 +784,7 @@ Communication
    :status: valid
    :version: 1
    :tags: safety_mechanism
+   :valid_from: v1.0.0
 
    The SW-platform shall support safe communication.
 
@@ -787,6 +810,7 @@ Communication
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the following automotive network
    protocols
@@ -843,6 +867,7 @@ Time
    :rationale: Enables the system to compare events chronologically.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide a time synchronization framework to synchronize its clock
    to Time Master within the vehicle.
@@ -855,6 +880,7 @@ Time
    :rationale: Enables an application to correlate its data with a vehicle-internal time reference for event timestamp and chronological events comparison.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide access to synchronized vehicle time.
 
@@ -877,6 +903,7 @@ Time
    :rationale: Enables the system to validate a certificate or token with temporal validity conditions, adding a UTC-timestamp to a data set.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide a framework to synchronize the clock to external-to-vehicle absolute time base (UTC).
 
@@ -888,6 +915,7 @@ Time
    :rationale: Enables an application to correlate its data with an absolute vehicle-external time reference for event timestamping and chronological events comparison.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide access to the absolute time base, synchronized with external time sources.
 
@@ -899,6 +927,7 @@ Time
    :rationale: Enables an application to get the current system time, which is essential for time-sensitive operations and event scheduling, via common, mockable and standardized API.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide access to the current high precision clock from the system time provider in nanoseconds.
 
@@ -912,6 +941,7 @@ Time
    :rationale: Enables an application to get the current system time, which is essential for time-sensitive operations and event scheduling, via common, mockable and standardized API.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide access to the current monotonic clock from the system time provider.
 
@@ -1062,6 +1092,7 @@ Diagnostics and Fault Management
    :rationale: Enables modern, scalable diagnostics using a standard REST-based protocol to improve integration, interoperability, and maintainability.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support vehicle diagnostics via the SOVD protocol as defined in ISO 17978, to allow scalable and secure diagnostic access.
 
@@ -1073,6 +1104,7 @@ Diagnostics and Fault Management
    :rationale: Enables applications and components to report faults in a structured, reusable, and system-wide accessible manner.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support a reusable fault reporting infrastructure that enables applications and SW-platform components to report, persist, and manage diagnostic fault information.
 
@@ -1084,6 +1116,7 @@ Diagnostics and Fault Management
    :rationale: Enables reading of Diagnostic Trouble Codes (DTCs) from the ECU for various use-cases like production or maintenance.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide users the ability to retrieve current Diagnostic Trouble Codes (DTCs) from the ECU via the SOVD protocol.
 
@@ -1095,6 +1128,7 @@ Diagnostics and Fault Management
    :rationale: Enables OEMs and developers to implement system-specific or project-specific routines for diagnostic control and testing.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support extensibility mechanisms that allow integration of custom diagnostic services and routines via the SOVD interface.
 
@@ -1106,6 +1140,7 @@ Diagnostics and Fault Management
    :rationale: Ensures continued usability of existing test infrastructure, avoiding costly replacement of legacy tools and ensuring fulfillment of legal requirements.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide compatibility with UDS-based testers by offering a proxy to translate UDS requests into SOVD-compatible actions.
 
@@ -1117,6 +1152,7 @@ Diagnostics and Fault Management
    :rationale: Ensures continued operability of ECUs that are not SOVD-capable.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support integration with ECUs that use UDS by providing a compatibility adapter to translate SOVD requests to UDS commands.
 
@@ -1128,6 +1164,7 @@ Diagnostics and Fault Management
    :rationale: Enables the system to operate in modern, distributed vehicle architectures where diagnostics span multiple ECUs and subsystems.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support distributed diagnostics across multiple ECUs and network segments, enabling routing and aggregation of diagnostic data.
 
@@ -1139,6 +1176,7 @@ Diagnostics and Fault Management
    :rationale: Diagnostic access allows deep system introspection and manipulation, which must be protected against unauthorized use.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall enforce secure access control for all diagnostic interfaces, including authentication, encryption, and role-based access enforcement.
 
@@ -1265,6 +1303,7 @@ Developer experience
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the tracing of communication events for internal
    and external communication systems.
@@ -1304,6 +1343,7 @@ Developer experience
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide a method and interface to enable
    debugging of the software on target and in vehicle.
@@ -1316,6 +1356,7 @@ Developer experience
    :rationale: Enables unit, component and integration testing for both SW-platform related and non-platform related applications.
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall provide support for mocking its public interfaces,
    enabling unit, component and integration testing of applications.
@@ -1328,6 +1369,7 @@ Developer experience
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support implementation of applications in the following
    programming languages up to the highest ASIL level as defined in :need:`stkh_req__dependability__automotive_safety`:
@@ -1357,6 +1399,7 @@ Developer experience
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support the following logging setups:
 
@@ -1375,6 +1418,7 @@ Developer experience
    :rationale: tbd
    :status: valid
    :version: 1
+   :valid_from: v1.0.0
 
    The SW-platform shall support logging of data to memory which survives a reboot
    cycle.


### PR DESCRIPTION
## What

Adds `:valid_from: v1.0.0` to `feat_req` entries (where not already set) for the following features, and to the stakeholder requirements they are linked to via `derived_from`:

- baselibs (already set — no changes)
- logging (`analysis-infra/logging`)
- communication (main, `ipc`, `some_ip_gateway`)
- config_management (`configuration/config_mgmt`)
- persistency
- lifecycle
- time
- diagnostics (already set — no changes)
- security_crypto (crypto)

## Details

- 289 `feat_req` insertions across the feature requirement files.
- 44 stakeholder requirement insertions in `docs/requirements/stakeholder/index.rst` (only the `stkh_req` entries referenced by the above features' `derived_from`, and only where `valid_from` was missing).
- Placement follows existing conventions: after `:version:` for `feat_req`; as the last field (after `:tags:` where present) for `stkh_req`.
- Entries that already had `valid_from` were left untouched.

## Notes

- No "network management (nm)" feature exists in the repo, so it was skipped.
- Total: 333 insertions across 10 files.

## Verification

- `bazel run //:docs` builds successfully; schema validation passes with 0 warnings.
- The 6 non-fatal traceability warnings in lifecycle are pre-existing (verified by rebuilding against the base without these changes) and unrelated to this change.
