### PR TITLE
Update baselibs feature requirements per inspection findings

### DIFF
--- a/docs/features/baselibs/docs/requirements/chklst_req_inspection.rst
+++ b/docs/features/baselibs/docs/requirements/chklst_req_inspection.rst
@@ -72,12 +72,9 @@ See also :need:`doc_concept__wp_inspections` for further information about revie
     * - REQ_02_02
       - Is the requirement description *unambiguous* ?
       - Especially search for "weak words" like "about", "etc.", "relevant" and others (see the internet documentation on this). This check shall be supported by tooling.
-      - NO
-      - - :need:`feat_req__baselibs__core_utilities`: It's open to interpretation what "core software utilities and common infrastructure components" means. Listing them explicitly or linking this requirement to an existing list would be better. Also "multiple" seems vague, and also implies that the number of modules using base libs is relevant here. maybe just drop it.
-        - :need:`feat_req__baselibs__safety`: The phrase "selected functionalities" makes is vague. It could be interpreted as such that only a "selected" subset of functionalities that need to be ASIL-B are actually ASIL-B, or maybe "selected functionalities" are on the user side? I assume that this requirement is to be understood as: "Each base library component shall be qualified at the same safety integrity level as required by its consuming platform components, up to ASIL-B.". If that is true - then it needs to be rephrased in that way.
-        - :need:`feat_req__baselibs__consistent_apis`: It's unclear what is meant by ""consistent""? Consistent naming, error handling...? Consistency over time? My interpretation is that is should use uniform API design patterns across all components, but it's not entirely clear.
-        - :need:`feat_req__baselibs__containers_library`: "container types not present in the C++ standard library" depends on which C++ standard is used.
-      - https://github.com/eclipse-score/score/issues/2885
+      - YES
+      - Check is supported by tooling and no ambiguities present any more after inspection fixes.
+      -
     * - REQ_02_03
       - Is the requirement description *atomic* ?
       - A good way to think about this is to consider if the requirement may be tested by one (positive) test case or needs more of these. The requirement formulation template should also avoid being non-atomic already. Note that there are cases where also non-atomic requirements are the better ones, for example if those are better understandable.
@@ -99,28 +96,15 @@ See also :need:`doc_concept__wp_inspections` for further information about revie
     * - REQ_03_01
       - Is the *linkage to the parent requirement* correct?
       - Linkage to correct levels and ASIL attributes is checked automatically, but it needs checking if the child requirement implements (at least) a part of the parent requirement.
-      - NO
-      - Following requirements are missing links to :need:`stkh_req__dependability__automotive_safety` which should be added to justify their safety classification:
-
-        - :need:`feat_req__baselibs__json_library`
-        - :need:`feat_req__baselibs__result_library`
-        - :need:`feat_req__baselibs__containers_library`
-        - :need:`feat_req__baselibs__bitmanipulation`
-        - :need:`feat_req__baselibs__memory_library`
-        - :need:`feat_req__baselibs__concurrency_library`
-      - https://github.com/eclipse-score/score/issues/2885
+      - YES
+      - Missing links to :need:`stkh_req__dependability__automotive_safety` added with https://github.com/eclipse-score/score/issues/2885
+      -
     * - REQ_04_01
       - Is the requirement *internally and externally consistent*?
       - Does the requirement contradict other requirements within the same or higher levels? One may restrict the search to the feature for component requirements, for features to other features using same components. Is the description of the requirement consistent with all its attributes (if not already part of another check, e.g. does the title fit?).
-      - NO
-      - No logical inconsistencies, just minor naming issues:
-
-        - :need:`feat_req__baselibs__json_library`: To be consistent with the titles of other requirements the title should be changed: JSON-Library -> JSON Library
-        - :need:`feat_req__baselibs__flatbuffers_library`: FlatBuffers-Library -> FlatBuffers Library
-        - :need:`feat_req__baselibs__result_library`: Title is "Exception-Free Development Support" but the ID is result_library. The title describes the constraint, and not the library name. This is inconsistent to the naming of other components.
-        - :need:`feat_req__baselibs__filesystem_library`: Filesystem-Library -> Filesystem Library
-        - :need:`feat_req__baselibs__memory_library`: Description uses "baselibs" while all other requirements use "base libraries". Internally inconsistent with naming convention used throughout the document.
-      - https://github.com/eclipse-score/score/issues/2885
+      - YES
+      - No logical inconsistencies, minor naming issues fixed with https://github.com/eclipse-score/score/issues/2885
+      -
     * - REQ_05_01
       - Do the software requirements consider *timing constraints*?
       - This checkpoint encourages to think about timing constraints even if those are not explicitly mentioned in the parent requirement. If the reviewer of a requirement already knows or suspects that the code execution will be consuming a lot of time, one should think of the expectation of a "user".
@@ -148,26 +132,22 @@ See also :need:`doc_concept__wp_inspections` for further information about revie
     * - REQ_07_02
       - Is the *security* attribute set correctly?
       - For feature requirements this checklist item is supported by automated check: "Every requirement which satisfies a stakeholder requirement with security attribute set to YES inherits this". But the feature requirements/architecture may additionally also be subject to a :need:`wp__feature_security_analysis`
-      - NO
-      - all the feature requirements here inherit from :need:`stkh_req__functional_req__base_libraries`, which has a security set to YES. This means all the requirements here should also set this attribute to YES.
-      - https://github.com/eclipse-score/score/issues/2885
+      - YES
+      - All the feature requirements here inherit from :need:`stkh_req__functional_req__base_libraries` have the security=YES attribute set.
+      -
     * - REQ_08_01
       - Is the requirement *verifiable*?
       - If at the time of the inspection already tests are created for the requirement, the answer is yes. This can be checked via traces, but also :need:`gd_req__req_attr_test_covered` shows this. In case the requirement is not sufficiently traced to test cases already, a test expert is invited to the inspection to give their opinion whether the requirement is formulated in a way that supports test development and the available test infrastructure is sufficient to perform the test.
       - YES
       - The following feature requirements are high-level and not directly testable
 
-        - :need:`feat_req__baselibs__core_utilities`
-        - :need:`feat_req__baselibs__safety`
         - :need:`feat_req__baselibs__multi_language_apis`
-        - :need:`feat_req__baselibs__consistent_apis`
-        - :need:`feat_req__baselibs__maintainable_design`
-        - :need:`feat_req__baselibs__security`
 
         But these high-level requirements are decomposed into detailed component requirements that are testable.
 
         Following feature requirements are directly testable:
 
+        - :need:`feat_req__baselibs__utils_library`
         - :need:`feat_req__baselibs__json_library`
         - :need:`feat_req__baselibs__flatbuffers_library`
         - :need:`feat_req__baselibs__result_library`
@@ -177,7 +157,7 @@ See also :need:`doc_concept__wp_inspections` for further information about revie
         - :need:`feat_req__baselibs__memory_library`
         - :need:`feat_req__baselibs__concurrency_library`
 
-        For these directly testable features, requirement wording is clear enough to derive test cases, and trace links from feature requirements to lower-level requirements and test cases are available
+        For these directly testable features, requirement wording is clear enough to derive test cases, and trace links from feature requirements to lower-level requirements and test cases are available.
       -
     * - REQ_08_02
       - Is the requirement verifiable by design or code review in case it is not feasibly testable?

--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -18,136 +18,93 @@ Requirements
 .. document:: Baselibs Requirements
    :id: doc__baselibs_requirements
    :status: valid
-   :version: 1
+   :version: 2
    :safety: ASIL_B
    :security: YES
    :realizes: wp__requirements_feat[version==1]
 
-.. feat_req:: Core Software Utilities
-   :id: feat_req__baselibs__core_utilities
+.. feat_req:: Utils Library
+   :id: feat_req__baselibs__utils_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__baselibs[version==1]
+   :status: valid
+   :version: 2
+   :valid_from: v1.0.0
+   :tags: inspected
+
+   The base libraries shall provide a utils library with general-purpose utility functionality, including Base64 encoding and decoding, scoped operations, string views, safe integer arithmetic, safe atomic operations, and defined program termination handling.
+
+.. feat_req:: Multi-Language APIs
+   :id: feat_req__baselibs__multi_language_apis
+   :reqtype: Functional
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dev_experience__prog_languages[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__baselibs[version==1]
+   :status: valid
+   :version: 2
+   :valid_from: v1.0.0
+   :tags: inspected
+
+   The base libraries shall provide APIs for C++, Rust, or both, depending on the requirements of consuming platform components.
+
+.. feat_req:: JSON Library
+   :id: feat_req__baselibs__json_library
+   :reqtype: Functional
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__baselibs[version==1]
+   :status: valid
+   :version: 2
+   :valid_from: v1.0.0
+   :tags: inspected
+
+   The base libraries shall provide a JSON library with parsing functionality.
+
+.. feat_req:: FlatBuffers Library
+   :id: feat_req__baselibs__flatbuffers_library
+   :reqtype: Functional
+   :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__base_libraries[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
-   The base libraries shall include core software utilities and common infrastructure components needed by multiple platform modules.
+   The base libraries shall provide a FlatBuffers library with serialization, read access, and structural verification of FlatBuffers data.
 
-.. feat_req:: Safety Relevance
-   :id: feat_req__baselibs__safety
+   .. note::
+      FlatBuffers library provides both ASIL-B and QM compliant functionality depending on the programming language,
+      the separation is done on component level.
+
+.. feat_req:: Static Reflection Library
+   :id: feat_req__baselibs__static_reflection_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
-   :tags: inspected
 
-   The base libraries shall implement functionality necessary to support safety-relevant platform components up to ASIL-B for selected functionalities.
+   The base libraries shall provide a static reflection library enabling compile-time reflection-based serialization and deserialization of C++ data structures.
 
-.. feat_req:: Multi-Language APIs
-   :id: feat_req__baselibs__multi_language_apis
-   :reqtype: Functional
-   :security: NO
-   :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dev_experience__prog_languages[version==1], stkh_req__dependability__automotive_safety[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall provide APIs for C++, Rust, or both, depending on the requirements of consuming platform components.
-
-.. feat_req:: Consistent APIs
-   :id: feat_req__baselibs__consistent_apis
-   :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dev_experience__prog_languages[version==1], stkh_req__overall_goals__reuse_of_app_soft[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall provide consistent APIs while respecting language-specific idioms.
-
-.. feat_req:: Maintainable Design
-   :id: feat_req__baselibs__maintainable_design
-   :reqtype: Non-Functional
-   :security: NO
-   :safety: QM
-   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__overall_goals__reuse_of_app_soft[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall be designed for maintainability and code reuse.
-
-.. feat_req:: Security Robustness
-   :id: feat_req__baselibs__security
-   :reqtype: Non-Functional
-   :security: YES
-   :safety: QM
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall adhere to secure coding standards to prevent vulnerabilities across platform components.
-
-.. feat_req:: JSON-Library
-   :id: feat_req__baselibs__json_library
-   :reqtype: Functional
-   :security: NO
-   :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall provide a JSON-Library with parsing functionality.
-
-.. feat_req:: FlatBuffers-Library
-   :id: feat_req__baselibs__flatbuffers_library
-   :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
-   :satisfied_by: feat__baselibs[version==1]
-   :status: valid
-   :version: 1
-   :valid_from: v1.0.0
-   :tags: inspected
-
-   The base libraries shall provide a FlatBuffers-Library with serialization, read access, and structural verification of FlatBuffers data.
-
-   .. note::
-      FlatBuffers-Library provides both ASIL-B and QM compliant functionality depending on the programming language,
-      the separation is done on component level.
-
-.. feat_req:: Exception-Free Development Support
+.. feat_req:: Result Library
    :id: feat_req__baselibs__result_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
@@ -156,12 +113,12 @@ Requirements
 .. feat_req:: Panic-Free Development Support
    :id: feat_req__baselibs__panic_free_development
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
 
    The base libraries shall provide error handling mechanisms that enable development without relying on Rust panics.
@@ -170,26 +127,26 @@ Requirements
 .. feat_req:: Container Library
    :id: feat_req__baselibs__containers_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
-   The base libraries shall provide a container library offering additional container types not present in the C++ standard library.
+   The base libraries shall provide a container library offering additional container types not present in the ISO C++17 standard library.
 
 .. feat_req:: ABI-Compatible Containers
    :id: feat_req__baselibs__abi_containers
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1] ,stkh_req__communication__abi_compatible[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__communication__abi_compatible[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
 
    The base libraries shall provide a library of containers that can serve as the basis for ABI-compatible container data structures.
@@ -197,26 +154,26 @@ Requirements
 .. feat_req:: Bit Manipulation Library
    :id: feat_req__baselibs__bitmanipulation
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
    The base libraries shall provide bit manipulation utilities for low-level operations on integral types.
 
-.. feat_req:: Filesystem-Library
+.. feat_req:: Filesystem Library
    :id: feat_req__baselibs__filesystem_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
@@ -227,24 +184,24 @@ Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
-   The baselibs shall provide a memory management library that includes utilities for shared memory operations, polymorphic memory resources, position-independent pointers, endianness conversion, and inter-process synchronization mechanisms.
+   The base libraries shall provide a memory management library that includes utilities for shared memory operations, polymorphic memory resources, position-independent pointers, endianness conversion, and inter-process synchronization mechanisms.
 
 .. feat_req:: Concurrency Library
    :id: feat_req__baselibs__concurrency_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
    :tags: inspected
 
@@ -253,12 +210,12 @@ Requirements
 .. feat_req:: Hash Library
    :id: feat_req__baselibs__hash_library
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: stkh_req__functional_req__base_libraries[version==1]
+   :derived_from: stkh_req__functional_req__base_libraries[version==1], stkh_req__dependability__automotive_safety[version==1]
    :satisfied_by: feat__baselibs[version==1]
    :status: valid
-   :version: 1
+   :version: 2
    :valid_from: v1.0.0
 
    The base libraries shall provide a hash library supporting cryptographic hash


### PR DESCRIPTION
Applies the fixes for the baselibs feature requirement inspection (#2812), tracked in eclipse-score/baselibs#189.

- REQ_02_02 (unambiguous): replaced `feat_req__baselibs__core_utilities` and `feat_req__baselibs__safety` with a more specific `feat_req__baselibs__utils_library`; removed `feat_req__baselibs__consistent_apis`, `feat_req__baselibs__maintainable_design`, and `feat_req__baselibs__security`; added `feat_req__baselibs__static_reflection_library`; pinned containers to the ISO C++17 standard library.
- REQ_03_01 (linkage): added `stkh_req__dependability__automotive_safety` to all ASIL-B requirements that lacked it.
- REQ_04_01 (consistency): normalized titles (JSON/FlatBuffers/Filesystem/Result Library) and unified "base libraries" wording.
- REQ_07_02 (security): set `:security: YES` on all requirements to inherit from `stkh_req__functional_req__base_libraries`.

Fixes eclipse-score/baselibs#189