### PR TITLE
Fix ref documentation

### DIFF
--- a/docs/design_decisions/DR-001-arch.md
+++ b/docs/design_decisions/DR-001-arch.md
@@ -10,7 +10,7 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
+(DR-001-Arch)=
 # DR-001-Arch: Rust Readiness for Safety-Critical Components
 
 * **Date:** 2026-03-06

--- a/docs/design_decisions/DR-002-arch.md
+++ b/docs/design_decisions/DR-002-arch.md
@@ -10,7 +10,7 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
+(DR-002-Arch)=
 # DR-002-Arch: Library Delivery Model (Static vs. Dynamic)
 
 * **Date:** 2026-05-15
@@ -170,7 +170,7 @@ The default delivery model is static libraries. Individual modules may opt in to
 | Integrator usability           |      +      |      +       |  ++  |         +         |
 | Maintenance effort             |     ++      |      +       |  --  |         +         |
 
-For detailed update granularity and performance assessments, see [Detailed Assessments](DR-002-arch/detailed_assessments.md).
+For detailed update granularity and performance assessments, see :ref:`Detailed Assessments <DR-002-Arch-detailed-assessments>`).
 
 ## Decision Proposal
 

--- a/docs/design_decisions/DR-002-arch/considerations.md
+++ b/docs/design_decisions/DR-002-arch/considerations.md
@@ -13,7 +13,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # DR-002-Arch: Considerations
 
-This page provides detailed considerations for the [Library Delivery Model](../DR-002-arch.md) design decision.
+
+This page provides detailed considerations for the :ref:`Library Delivery Model <DR-002-Arch>` design decision
 
 ## Architectural Note: Internal Composition of Shared Libraries
 
@@ -76,7 +77,8 @@ This composition model applies to all options that involve shared libraries (Opt
 
 ## Cross-Language Interoperability (C++ ↔ Rust)
 
-S-CORE uses both C++ and Rust (see [DR-001-Arch](../DR-001-arch.md)). Modules written in one language may need to be consumed by applications or other modules written in the other. The library delivery model affects cross-language interoperability (FFI):
+:ref:`Library Delivery Model <DR-002-Arch>`).
+S-CORE uses both C++ and Rust (see :ref:`<DR-001-arch>`). Modules written in one language may need to be consumed by applications or other modules written in the other. The library delivery model affects cross-language interoperability (FFI):
 
 ### The Common Denominator: C ABI
 

--- a/docs/design_decisions/DR-002-arch/detailed_assessments.md
+++ b/docs/design_decisions/DR-002-arch/detailed_assessments.md
@@ -10,10 +10,11 @@ https://www.apache.org/licenses/LICENSE-2.0
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
+(DR-002-Arch-detailed-assessments)=
 # DR-002-Arch: Detailed Assessments
 
-This page provides detailed evaluation assessments for the [Library Delivery Model](../DR-002-arch.md) design decision.
+                                                            
+This page provides detailed evaluation assessments for the :ref:`Library Delivery Model <DR-002-Arch>` design decision.
 
 ## Update Granularity — Detailed Assessment
 


### PR DESCRIPTION
Fixes reference documentation in design decision documents.

Copy of the changes from #3082 (which is itself a copy of #3072 without `valid_from` to avoid merge conflicts).