### PR TITLE
chore(ci): stop updating bazel dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,15 +48,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
-  - package-ecosystem: bazel
-    directory: /
-    schedule:
-      interval: daily
-    groups:
-      all-in-one:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"


### PR DESCRIPTION
We dont want to auto update external dependencies. Internal dependencies are updated via renovate.