### PR TITLE
remove v0.5 beta in feature description

### DIFF
--- a/docs/features/baselibs/index.rst
+++ b/docs/features/baselibs/index.rst
@@ -14,8 +14,8 @@
 
 .. _baselibs_feature:
 
-Base Libraries (v0.5 beta)
-###########################
+Base Libraries
+##############
 
 .. document:: Base Libraries
    :id: doc__baselibs

--- a/docs/features/communication/index.rst
+++ b/docs/features/communication/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -14,8 +14,8 @@
 
 .. _com_feature:
 
-Communication (v0.5 beta)
-##########################
+Communication
+#############
 
 .. document:: Communication
    :id: doc__com

--- a/docs/features/frameworks/feo/index.rst
+++ b/docs/features/frameworks/feo/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -12,8 +12,8 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-Fixed execution order framework (FEO) (v0.5 beta)
-#################################################
+Fixed execution order framework
+###############################
 
 .. document:: Fixed execution order framework
    :id: doc__frameworks_feo

--- a/docs/features/orchestration/index.rst
+++ b/docs/features/orchestration/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -15,8 +15,8 @@
 
 .. _orch_feature:
 
-Orchestration (v0.5 beta)
-##########################
+Orchestration
+#############
 
 .. document:: Orchestration
    :id: doc__orchestration

--- a/docs/features/persistency/index.rst
+++ b/docs/features/persistency/index.rst
@@ -1,6 +1,6 @@
 ..
    # *******************************************************************************
-   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.
@@ -14,8 +14,8 @@
 
 .. _features_persistency:
 
-Persistency (v0.5 beta)
-########################
+Persistency
+###########
 
 .. document:: Persistency
    :id: doc__persistency


### PR DESCRIPTION
Cleaning-Up of the Feature Requirements:

Removed V0.5 Beta in the Headlines of Base Libs, Communication, FEO, Orchestration and Persistency