### PR TITLE
docs: set satisfied_by on feature and component requirements

### DIFF
--- a/docs/features/ai_platform/architecture/index.rst
+++ b/docs/features/ai_platform/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: AI-Platform Architecture
+   :id: doc__ai_platform_architecture
+   :status: draft
+   :version: 1
+   :safety: ASIL_B
+   :security: NO
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: AI-Platform
+   :id: feat__ai_platform
+   :security: NO
+   :safety: ASIL_B
+   :status: valid
+   :version: 1

--- a/docs/features/ai_platform/gen_ai/architecture/index.rst
+++ b/docs/features/ai_platform/gen_ai/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Gen-AI Architecture
+   :id: doc__gen_ai_architecture
+   :status: draft
+   :version: 1
+   :safety: QM
+   :security: NO
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Gen-AI
+   :id: feat__gen_ai
+   :security: NO
+   :safety: QM
+   :status: valid
+   :version: 1

--- a/docs/features/ai_platform/gen_ai/requirements/index.rst
+++ b/docs/features/ai_platform/gen_ai/requirements/index.rst
@@ -23,6 +23,7 @@ Requirements
    :security: NO
    :safety: QM
    :derived_from: stkh_req__gen_ai__enablement[version==1]
+   :satisfied_by: feat__gen_ai[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -35,6 +36,7 @@ Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__gen_ai__interaction[version==1]
+   :satisfied_by: feat__gen_ai[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -47,6 +49,7 @@ Requirements
    :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__gen_ai__safety_filter[version==1]
+   :satisfied_by: feat__gen_ai[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -59,6 +62,7 @@ Requirements
    :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__gen_ai__vehicle_com[version==1]
+   :satisfied_by: feat__gen_ai[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0

--- a/docs/features/ai_platform/requirements/index.rst
+++ b/docs/features/ai_platform/requirements/index.rst
@@ -23,6 +23,7 @@ Requirements
    :security: NO
    :safety: QM
    :derived_from: stkh_req__ai_platform__enablement[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -35,6 +36,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__ai_platform__safety_critical[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -47,6 +49,7 @@ Requirements
    :security: NO
    :safety: QM
    :derived_from: stkh_req__ai_platform__runtime_efficiency[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -59,6 +62,7 @@ Requirements
    :security: NO
    :safety: QM
    :derived_from: stkh_req__ai_platform__platform_portability[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -71,6 +75,7 @@ Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__ai_platform__model_security[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -83,6 +88,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__ai_platform__runtime_determinism[version==1]
+   :satisfied_by: feat__ai_platform[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0

--- a/docs/features/code_generation/architecture/index.rst
+++ b/docs/features/code_generation/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Code-Generation Architecture
+   :id: doc__code_generation_architecture
+   :status: draft
+   :version: 1
+   :safety: ASIL_B
+   :security: NO
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Code-Generation
+   :id: feat__code_generation
+   :security: NO
+   :safety: ASIL_B
+   :status: valid
+   :version: 1

--- a/docs/features/code_generation/requirements/index.rst
+++ b/docs/features/code_generation/requirements/index.rst
@@ -23,6 +23,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__dev_experience__idl_support[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -37,6 +38,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -50,6 +52,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -63,6 +66,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -77,6 +81,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -90,6 +95,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -105,6 +111,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__ai_platform__runtime_determinism[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -121,6 +128,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__ai_platform__runtime_determinism[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -136,6 +144,7 @@ Requirements
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__ai_platform__runtime_determinism[version==1]
+   :satisfied_by: feat__code_generation[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0

--- a/docs/features/configuration/config_mgmt/architecture/index.rst
+++ b/docs/features/configuration/config_mgmt/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Configuration Management Architecture
+   :id: doc__config_mgmt_architecture
+   :status: draft
+   :version: 1
+   :safety: ASIL_B
+   :security: YES
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Configuration Management
+   :id: feat__config_mgmt
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+   :version: 1

--- a/docs/features/configuration/config_mgmt/index.rst
+++ b/docs/features/configuration/config_mgmt/index.rst
@@ -30,6 +30,7 @@ Configuration Management
 .. toctree::
    :hidden:
 
+   architecture/index.rst
    requirements/index.rst
 
 Feature flag

--- a/docs/features/configuration/config_mgmt/requirements/index.rst
+++ b/docs/features/configuration/config_mgmt/requirements/index.rst
@@ -24,6 +24,7 @@ Terms and definitions
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -36,6 +37,7 @@ Terms and definitions
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -51,6 +53,7 @@ Data Housekeeping
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -63,6 +66,7 @@ Data Housekeeping
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -75,6 +79,7 @@ Data Housekeeping
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -87,6 +92,7 @@ Data Housekeeping
    :security: NO
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -99,6 +105,7 @@ Data Housekeeping
    :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -111,6 +118,7 @@ Data Housekeeping
    :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -123,6 +131,7 @@ Data Housekeeping
    :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -138,6 +147,7 @@ Parameter Provision
    :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -150,6 +160,7 @@ Parameter Provision
    :security: YES
    :safety: QM
    :derived_from: stkh_req__functional_req__file_based[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -165,6 +176,7 @@ Parameter Qualification
    :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__functional_req__safe_config[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -177,6 +189,7 @@ Parameter Qualification
    :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__functional_req__safe_config[version==1]
+   :satisfied_by: feat__config_mgmt[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0

--- a/docs/features/diagnostics/architecture/index.rst
+++ b/docs/features/diagnostics/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Diagnostics Architecture
+   :id: doc__diagnostics_architecture
+   :status: draft
+   :version: 1
+   :safety: QM
+   :security: YES
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Diagnostics
+   :id: feat__diagnostics
+   :security: YES
+   :safety: QM
+   :status: valid
+   :version: 1

--- a/docs/features/diagnostics/index.rst
+++ b/docs/features/diagnostics/index.rst
@@ -33,6 +33,7 @@ Diagnostic and Fault Management
    :titlesonly:
    :hidden:
 
+   architecture/index
    requirements/index
 
 Feature flag

--- a/docs/features/diagnostics/requirements/index.rst
+++ b/docs/features/diagnostics/requirements/index.rst
@@ -26,6 +26,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -38,6 +39,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1], stkh_req__diagnostics__secure_access[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -50,6 +52,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -62,6 +65,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -74,6 +78,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__secure_access[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -86,6 +91,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__distributed_support[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -98,6 +104,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1], stkh_req__diagnostics__secure_access[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -110,6 +117,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -122,6 +130,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__custom_services[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -134,6 +143,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__custom_services[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -146,6 +156,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -158,6 +169,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -170,6 +182,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -182,6 +195,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1], stkh_req__diagnostics__dtc_read_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -194,6 +208,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -206,6 +221,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1], stkh_req__diagnostics__dtc_read_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -218,6 +234,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__fault_reporting[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -230,6 +247,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__uds_ecus[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -242,6 +260,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__uds_ecus[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -254,6 +273,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__uds_tester_compat[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -266,6 +286,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__uds_tester_compat[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.5.0
@@ -278,6 +299,7 @@ Diagnostic and Fault Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__diagnostics__via_sovd[version==1], stkh_req__diagnostics__dtc_read_sovd[version==1]
+   :satisfied_by: feat__diagnostics[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0

--- a/docs/features/frameworks/daal/architecture/index.rst
+++ b/docs/features/frameworks/daal/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Deterministic App Abstraction Layer Architecture
+   :id: doc__daal_architecture
+   :status: draft
+   :version: 1
+   :safety: QM
+   :security: NO
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Deterministic App Abstraction Layer
+   :id: feat__daal
+   :security: NO
+   :safety: QM
+   :status: valid
+   :version: 1

--- a/docs/features/frameworks/daal/index.rst
+++ b/docs/features/frameworks/daal/index.rst
@@ -28,6 +28,7 @@ Deterministic App Abstraction Layer
    :maxdepth: 2
    :caption: Contents
 
+   architecture/index.rst
    requirements/index.rst
 
 Feature flag

--- a/docs/features/frameworks/daal/requirements/index.rst
+++ b/docs/features/frameworks/daal/requirements/index.rst
@@ -24,6 +24,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__app_architectures__support_time[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -36,6 +37,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__overall_goals__reuse_of_app_soft[version==1], stkh_req__execution_model__processes[version==1], stkh_req__execution_model__low_power[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -48,6 +50,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__functional_req__operating_system[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -62,6 +65,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__app_architectures__support_data[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -74,6 +78,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__dev_experience__logging_support[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -86,6 +91,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -98,6 +104,7 @@ General
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1]
+   :satisfied_by: feat__daal[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0

--- a/docs/features/lifecycle/requirements/index.rst
+++ b/docs/features/lifecycle/requirements/index.rst
@@ -32,6 +32,7 @@ Launching Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -44,6 +45,7 @@ Launching Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -58,6 +60,7 @@ Launching Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -71,6 +74,7 @@ Launching Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -88,6 +92,7 @@ Conditional Launching
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -104,6 +109,7 @@ Process Management
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -116,6 +122,7 @@ Process Management
     :reqtype: Functional
     :security: NO
     :safety: ASIL_B
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -133,6 +140,7 @@ Run targets
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -146,6 +154,7 @@ Run targets
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -158,6 +167,7 @@ Run targets
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -174,6 +184,7 @@ Terminating Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -186,6 +197,7 @@ Terminating Processes
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -203,6 +215,7 @@ Control Interface
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -215,6 +228,7 @@ Control Interface
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -229,6 +243,7 @@ Control Interface
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -244,6 +259,7 @@ Control Interface
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -261,6 +277,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -275,6 +292,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -288,6 +306,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -302,6 +321,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -316,6 +336,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -332,6 +353,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v2.0.0
@@ -345,6 +367,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__safety_features_1[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -357,6 +380,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__dependability__safety_features_1[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -369,6 +393,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__dependability__safety_features_1[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -382,6 +407,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__dependability__safety_features_1[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -395,6 +421,7 @@ Monitoring, Notification and Recovery
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__dependability__safety_features_1[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -411,6 +438,7 @@ Logging
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -428,6 +456,7 @@ Configuration file
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__functional_req__file_based[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -442,6 +471,7 @@ Configuration file
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__functional_req__file_based[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -455,6 +485,7 @@ Configuration file
     :security: NO
     :safety: ASIL_B
     :derived_from: stkh_req__functional_req__file_based[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0
@@ -468,6 +499,7 @@ Configuration file
     :security: NO
     :safety: QM
     :derived_from: stkh_req__execution_model__processes[version==1]
+    :satisfied_by: feat__lifecycle[version==1]
     :status: valid
     :version: 1
     :valid_from: v1.0.0

--- a/docs/features/orchestration/requirements/index.rst
+++ b/docs/features/orchestration/requirements/index.rst
@@ -80,6 +80,7 @@ Special Tasks and Preemption
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__orchestration[version==1]
    :status: invalid
    :version: 1
    :valid_from: v2.0.0
@@ -92,6 +93,7 @@ Special Tasks and Preemption
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__orchestration[version==1]
    :status: invalid
    :version: 1
    :valid_from: v2.0.0
@@ -320,6 +322,7 @@ Special Safety Task Integration
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__orchestration[version==1]
    :status: invalid
    :version: 1
    :valid_from: v2.0.0
@@ -432,6 +435,7 @@ General Constraints
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__automotive_safety[version==1]
+   :satisfied_by: feat__orchestration[version==1]
    :status: invalid
    :version: 1
    :valid_from: v2.0.0
@@ -444,6 +448,7 @@ General Constraints
    :security: YES
    :safety: ASIL_B
    :derived_from: stkh_req__execution_model__processes[version==1], stkh_req__dependability__automotive_safety[version==1], stkh_req__dependability__security_features[version==1], stkh_req__communication__inter_process[version==1]
+   :satisfied_by: feat__orchestration[version==1]
    :status: invalid
    :version: 1
    :valid_from: v2.0.0

--- a/docs/features/security_crypto/architecture/index.rst
+++ b/docs/features/security_crypto/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Security & Crypto Architecture
+   :id: doc__security_crypto_architecture
+   :status: draft
+   :version: 1
+   :safety: QM
+   :security: YES
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Security & Crypto
+   :id: feat__security_crypto
+   :security: YES
+   :safety: QM
+   :status: valid
+   :version: 1

--- a/docs/features/security_crypto/index.rst
+++ b/docs/features/security_crypto/index.rst
@@ -27,6 +27,7 @@ Security & Cryptography
 .. toctree::
    :hidden:
 
+   architecture/index.rst
    requirements/index.rst
 
 

--- a/docs/features/security_crypto/requirements/index.rst
+++ b/docs/features/security_crypto/requirements/index.rst
@@ -26,6 +26,7 @@ Symmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -38,6 +39,7 @@ Symmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -50,6 +52,7 @@ Symmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -62,6 +65,7 @@ Symmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -74,6 +78,7 @@ Symmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -89,6 +94,7 @@ Asymmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -101,6 +107,7 @@ Asymmetric Encryption
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -117,6 +124,7 @@ Digital Signatures
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -129,6 +137,7 @@ Digital Signatures
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -141,6 +150,7 @@ Digital Signatures
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -156,6 +166,7 @@ Message Authentication Code (MAC)
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -172,6 +183,7 @@ Hashing
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -184,6 +196,7 @@ Hashing
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -196,6 +209,7 @@ Hashing
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -211,6 +225,7 @@ Key Derivation Functions (KDF)
    :reqtype: Functional
    :security: YES
    :safety: QM
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -228,6 +243,7 @@ Random Number Generation
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -240,6 +256,7 @@ Random Number Generation
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -255,6 +272,7 @@ Certificate Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -271,6 +289,7 @@ Key Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -283,6 +302,7 @@ Key Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -295,6 +315,7 @@ Key Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -307,6 +328,7 @@ Key Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -319,6 +341,7 @@ Key Management
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -335,6 +358,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v2.0.0
@@ -348,6 +372,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -361,6 +386,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -373,6 +399,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -385,6 +412,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -398,6 +426,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -411,6 +440,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -424,6 +454,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -436,6 +467,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -448,6 +480,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -461,6 +494,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -473,6 +507,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -486,6 +521,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -498,6 +534,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -510,6 +547,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -523,6 +561,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -536,6 +575,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -549,6 +589,7 @@ Non-Functional Requirements
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -566,6 +607,7 @@ Secure Communication Protocols
    :security: YES
    :safety: QM
    :derived_from: stkh_req__dependability__security_features[version==1]
+   :satisfied_by: feat__security_crypto[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0

--- a/docs/features/time/docs/architecture/index.rst
+++ b/docs/features/time/docs/architecture/index.rst
@@ -1,0 +1,31 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Feature Architecture
+====================
+
+.. document:: Time Architecture
+   :id: doc__time_architecture
+   :status: draft
+   :version: 1
+   :safety: ASIL_B
+   :security: YES
+   :realizes: wp__feature_arch[version==1]
+
+.. feat:: Time
+   :id: feat__time
+   :security: YES
+   :safety: ASIL_B
+   :status: valid
+   :version: 1

--- a/docs/features/time/docs/requirements/index.rst
+++ b/docs/features/time/docs/requirements/index.rst
@@ -24,6 +24,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__vehicle_time_sync[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -36,6 +37,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__vehicle_time_sync[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -56,6 +58,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -68,6 +71,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -86,6 +90,7 @@ Time Synchronization
    :security: NO
    :safety: ASIL_B
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -100,6 +105,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__vehicle_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -121,6 +127,7 @@ Time Synchronization
    :security: NO
    :safety: QM
    :derived_from: stkh_req__dev_experience__debugging[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -139,6 +146,7 @@ Time Synchronization to absolute external sources
    :security: YES
    :safety: QM
    :derived_from: stkh_req__time__absolute_time_sync[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -151,6 +159,7 @@ Time Synchronization to absolute external sources
    :security: YES
    :safety: QM
    :derived_from: stkh_req__time__absolute_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -163,6 +172,7 @@ Time Synchronization to absolute external sources
    :security: YES
    :safety: QM
    :derived_from: stkh_req__time__absolute_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -190,6 +200,7 @@ Time Synchronization to absolute external sources
    :security: YES
    :safety: QM
    :derived_from: stkh_req__time__absolute_time_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -209,6 +220,7 @@ Time Synchronization to absolute external sources
    :security: NO
    :safety: QM
    :derived_from: stkh_req__dev_experience__debugging[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -225,6 +237,7 @@ Local Clock
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__high_precision_clock_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -241,6 +254,7 @@ Local Clock
    :security: NO
    :safety: QM
    :derived_from: stkh_req__time__monotonic_clock_api[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0
@@ -256,6 +270,7 @@ Testability
    :security: NO
    :safety: QM
    :derived_from: stkh_req__dev_experience__mockup_public_apis[version==1]
+   :satisfied_by: feat__time[version==1]
    :status: valid
    :version: 1
    :valid_from: v1.0.0


### PR DESCRIPTION
Set the satisfied_by link on all feat_req/comp_req that were missing it, following the existing convention (feat_req -> feat__<feature>[version==1], comp_req -> comp__<component>[version==1]).

- 37 feat_req in existing features (lifecycle, orchestration)
- 118 feat_req in 8 features for which a parent feat:: need was created (feat__ai_platform, feat__gen_ai, feat__code_generation, feat__config_mgmt, feat__diagnostics, feat__daal, feat__security_crypto, feat__time)
- 63 lifecycle comp_req -> comp__lifecycle_launch_manager
- migrated comp_req__lifecycle__launch from belongs_to to satisfied_by

The 8 new feat:: needs are minimal (analogous to feat__feo/feat__os, without includes) since the underlying feature-request documents do not yet define logic_arc_int interfaces.

Result: 0 feat_req and 0 comp_req remain without satisfied_by. Validated with `bazel build //:docs` (success).