### PR TITLE
Fix malformed and non-reST links in docs

### DIFF
--- a/docs/contribute/general/git.rst
+++ b/docs/contribute/general/git.rst
@@ -109,7 +109,7 @@ required. E.g. **"Add unit test for class XY"** and not "I added unit
 tests", "Adding unit tests" or "Various minor changes".
 
 Additionally, the following specification for the content shall apply for
-commit messages (according to [Eclipse Git Commit Records](https://www.eclipse.org/projects/handbook/#resources-commit)):
+commit messages (according to `Eclipse Git Commit Records <https://www.eclipse.org/projects/handbook/#resources-commit>`_):
 
 Summary
 =======
@@ -233,5 +233,5 @@ Then, push the new branch to the remote repository and create a new pull-request
 This strategy is easier to understand, but has the downside that the discussion in the old pull-request is not automatically transferred to the new pull-request.
 
 The most efficient approach is to do either clean-up together with someone experienced in Git.
-Such a [pairing session](https://en.wikipedia.org/wiki/Pair_programming) can show you how to "think Git".
+Such a `pairing session <https://en.wikipedia.org/wiki/Pair_programming>`_ can show you how to "think Git".
 However, be confident: as long as you have not force-pushed the branch to GitHub, all changes you did are local and can be undone easily.

--- a/docs/design_decisions/DR-001-arch.md
+++ b/docs/design_decisions/DR-001-arch.md
@@ -58,7 +58,7 @@ Bazel integration + CI/CD integration ready and rolled out in few Rust repositor
 ### ✅ Static code analysis - linting
 
 - Bazel integration + CI/CD integration ready and rolled out in few Rust repositories that ensures code is aligned by same S-CORE wide configuration
-- tool have available report verification with confidence HIGH, meaning no qualification needed. (https://eclipse-score.github.io/score/main/score_tools/> ols_static_analysis_code_quality/clippy.html#doc_tool__clippy)
+- tool have available report verification with confidence HIGH, meaning no qualification needed. (https://eclipse-score.github.io/score/main/score_tools/tools_static_analysis_code_quality/clippy.html#doc_tool__clippy)
 
 
 ### 📈 Code coverage

--- a/docs/requirements/index.rst
+++ b/docs/requirements/index.rst
@@ -17,7 +17,7 @@
 Requirements
 ============
 
-Requirements are the formal descriptions of the requested capabilities or characteristics that the software platform or its components must fulfill. For further information see the `requirement concept <https://eclipse-score.github.io/process_description//main/process_areas/requirements_engineering/requirements_concept.html>`_ in the process description.
+Requirements are the formal descriptions of the requested capabilities or characteristics that the software platform or its components must fulfill. For further information see the `requirement concept <https://eclipse-score.github.io/process_description/main/process_areas/requirements_engineering/requirements_concept.html>`_ in the process description.
 
 The following stakeholder functional and non-functional requirements and platform assumptions describe this for S-CORE.
 


### PR DESCRIPTION
Correct the process description URL and convert markdown links in git documentation to valid reST links.