### PR TITLE
update some needextend directives to affect only the current file

### DIFF
--- a/docs/design_decisions/DR-003-strat.md
+++ b/docs/design_decisions/DR-003-strat.md
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 :status: proposed
 :context: Strategy
 :decision: Classify every module into one of three maturity levels — Release, Experimental, or Preview — based on requirement coverage and S-CORE process artifact completeness.
+:version: 1
 ```
 
 ---

--- a/docs/features/baselibs/docs/architecture/index.rst
+++ b/docs/features/baselibs/docs/architecture/index.rst
@@ -249,3 +249,6 @@ Interfaces
    :safety: ASIL_B
    :status: valid
    :version: 1
+
+.. needextend:: "c.this_doc()"
+   :+tags: baselibs

--- a/docs/features/baselibs/docs/requirements/chklst_req_inspection.rst
+++ b/docs/features/baselibs/docs/requirements/chklst_req_inspection.rst
@@ -20,6 +20,7 @@
    :safety: ASIL_B
    :security: YES
    :realizes: wp__requirements_inspect[version==1]
+   :tags: baselibs
 
 
 Requirement Inspection Checklist

--- a/docs/features/baselibs/docs/requirements/index.rst
+++ b/docs/features/baselibs/docs/requirements/index.rst
@@ -222,5 +222,5 @@ Requirements
    calculation (e.g. SHA-256, SHA-512) and checksum algorithms (e.g. CRC-32) over
    byte data and streams via a pluggable interface.
 
-.. needextend:: is_external == False and "__baselibs" in id
+.. needextend:: "c.this_doc()"
    :+tags: baselibs

--- a/docs/features/baselibs/index.rst
+++ b/docs/features/baselibs/index.rst
@@ -22,7 +22,7 @@ Base Libraries
    :status: valid
    :version: 1
    :safety: ASIL_B
-   :tags: feature_request
+   :tags: feature_request, baselibs
    :security: YES
    :realizes: wp__feat_request[version==1]
 

--- a/docs/modules/orchestrator/executor/docs/requirements/index.rst
+++ b/docs/modules/orchestrator/executor/docs/requirements/index.rst
@@ -62,6 +62,3 @@ Requirements
     - Replace the example content by the real content for your first requirement (according to :need:`gd_guidl__req_engineering`)
     - Set the status to valid and start the review/merge process
     - Add other needed requirements for your feature
-
-.. needextend:: "component_name" in id and is_external == False
-   :+tags: component_name

--- a/docs/modules/orchestrator/orchestrator/docs/requirements/index.rst
+++ b/docs/modules/orchestrator/orchestrator/docs/requirements/index.rst
@@ -62,6 +62,3 @@ Requirements
     - Replace the example content by the real content for your first requirement (according to :need:`gd_guidl__req_engineering`)
     - Set the status to valid and start the review/merge process
     - Add other needed requirements for your feature
-
-.. needextend:: "component_name" in id and is_external == False
-   :+tags: component_name


### PR DESCRIPTION
Since docs-as-code is moving towards supporting more fine grained docs-targets and embedding documentations into documentations, we cannot reliably predict cross document behavior of needextend. Sometimes it may affect a different set of needs than other times.

For example when needextend is applied to "x in docname", and someone else embedds the documentation into their module, and for whatever reason they also have "x", then suddenly the needextend will affect more files/needs.

This was already problematic in reference_integration in the past, we just got lucky due to "unique enough" names. But that will not suffice for a broader rollout.

---

This PR changes about **10% of needextend directives** in score. Those where the change is a single one-liner.

Verification performed: needs_json generated before the change, change applied, needs_json generated again, no diff.