### PR TITLE
remove superflued linking

### DIFF
--- a/docs/features/lifecycle/architecture/index.rst
+++ b/docs/features/lifecycle/architecture/index.rst
@@ -47,7 +47,6 @@ Interfaces
    :status: valid
    :version: 1
    :fulfils: feat_req__lifecycle__switch_run_targets[version==1], feat_req__lifecycle__liveliness_detection[version==1]
-   :includes: logic_arc_int_op__lifecycle__run, logic_arc_int_op__lifecycle__terminate,
 
    .. needarch::
       :scale: 50


### PR DESCRIPTION
This pull request makes a minor update to the `Interfaces` section in the `docs/features/lifecycle/architecture/index.rst` file, removing a reference to included logic architecture interface operations. No functional or technical behavior is changed.

The additional link is superflued, because the other way round link is also there. The optional link will is also removed in the pocess description and will be removed in the next docs as code version.