### PR TITLE
chore(docs): remove legacy score_docs_as_code configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ user.bazelrc
 
 # docs build artifacts
 /.venv_docs
-/_build*
+_build
 ubproject.toml
 
 # Vale - editorial style guide


### PR DESCRIPTION
<!-- repo-sync-policy: score-docs-as-code.legacy-documentation-cleanup -->

## Policy

**`score-docs-as-code.legacy-documentation-cleanup`**

Replace legacy documentation ignore entries and remove the obsolete docs/ubproject.toml configuration file.


## Why this repository?

This repository contains policy-managed legacy content in `.gitignore`. `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_docs_as_code`.

## Changes

- `.gitignore`: replace '/_build*' with '_build'

---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!WARNING]
> The tool producing this PR is in proof-of-concept stage. Review carefully.
