### PR TITLE
fix: Add `c.this_doc()` to needextend

### DIFF
--- a/docs/features/communication/ipc/requirements/index.rst
+++ b/docs/features/communication/ipc/requirements/index.rst
@@ -78,5 +78,5 @@ IPC Requirements
    The IPC binding shall ensure availability of its communication, so that the availability is independent per
    criticality level.
 
-.. needextend:: is_external == False and "__ipc" in id
+.. needextend:: c.this_doc() and is_external == False and "__ipc" in id
    :+tags: ipc

--- a/docs/features/communication/requirements/index.rst
+++ b/docs/features/communication/requirements/index.rst
@@ -778,5 +778,5 @@ Safety Impact
 
    The communication framework shall support safe communication up to ASIL-B.
 
-.. needextend:: is_external == False and "__com_" in id
+.. needextend:: c.this_doc() and is_external == False and "__com_" in id
    :+tags: com

--- a/docs/features/frameworks/feo/architecture/feature_architecture.rst
+++ b/docs/features/frameworks/feo/architecture/feature_architecture.rst
@@ -185,5 +185,5 @@ Logical Interfaces
 
   See static architecture.
 
-.. needextend:: docname is not None and "frameworks/feo/architecture" in docname
+.. needextend:: c.this_doc() and docname is not None and "frameworks/feo/architecture" in docname
    :+tags: frameworks_feo

--- a/docs/features/frameworks/feo/requirements/aou_req.rst
+++ b/docs/features/frameworks/feo/requirements/aou_req.rst
@@ -34,5 +34,5 @@ FEO Feature Assumption of Use Requirements
 
    Something shall be done.
 
-.. needextend:: is_external == False and "frameworks/feo/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "frameworks/feo/requirements" in docname
    :+tags: frameworks_feo

--- a/docs/features/frameworks/feo/requirements/feature_req.rst
+++ b/docs/features/frameworks/feo/requirements/feature_req.rst
@@ -386,5 +386,5 @@ Error Handling for S-CORE v0.5
     If an activity fails in the shutdown function, the primary process shall shutdown all remaining activities
     in arbitrary sequence and terminate itself.
 
-.. needextend:: is_external == False and "frameworks/feo/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "frameworks/feo/requirements" in docname
    :+tags: frameworks_feo

--- a/docs/features/orchestration/requirements/index.rst
+++ b/docs/features/orchestration/requirements/index.rst
@@ -455,5 +455,5 @@ General Constraints
 
    The system shall use the approved IPC feature exclusively for all inter-process synchronization.
 
-.. needextend:: is_external == False and "orchestration/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "orchestration/requirements" in docname
    :+tags: orchestration

--- a/docs/features/persistency/requirements/index.rst
+++ b/docs/features/persistency/requirements/index.rst
@@ -588,5 +588,5 @@ Persistency Requirements
    The Persistency shall support the production mode.
    The production mode should enforce the most restrictive data access controls feasible.
 
-.. needextend:: is_external == False and "persistency/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "persistency/requirements" in docname
    :+tags: persistency

--- a/docs/modules/communication/docs/requirements/aou_req.rst
+++ b/docs/modules/communication/docs/requirements/aou_req.rst
@@ -377,5 +377,5 @@ Assumptions of Use
    It shall be ensured that all safety relevant events/fields in the service type,
    are the same in all configurations.
 
-.. needextend:: is_external == False and "__communication_" in id
+.. needextend:: c.this_doc() and is_external == False and "__communication_" in id
    :+tags: communication

--- a/docs/modules/communication/lola/docs/requirements/index.rst
+++ b/docs/modules/communication/lola/docs/requirements/index.rst
@@ -32,5 +32,5 @@ see `LoLa trlc <https://github.com/eclipse-score/communication/blob/main/score/m
 LoLa component Assumptions of Use
 =================================
 
-.. needextend:: is_external == False and "lola" in id
+.. needextend:: c.this_doc() and is_external == False and "lola" in id
    :+tags: lola

--- a/docs/modules/feo/feo/docs/architecture/component_architecture.rst
+++ b/docs/modules/feo/feo/docs/architecture/component_architecture.rst
@@ -169,5 +169,5 @@ Interfaces
 
   See static architecture.
 
-.. needextend:: is_external == False and "feo/docs/architecture" in docname
+.. needextend:: c.this_doc() and is_external == False and "feo/docs/architecture" in docname
    :+tags: component_feo

--- a/docs/modules/feo/feo/docs/requirements/aou_req.rst
+++ b/docs/modules/feo/feo/docs/requirements/aou_req.rst
@@ -35,5 +35,5 @@ FEO Component Assumption of Use Requirements
 
    Anything shall be done.
 
-.. needextend:: is_external == False and "feo/docs/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "feo/docs/requirements" in docname
    :+tags: component_feo

--- a/docs/modules/feo/feo/docs/requirements/component_requirements.rst
+++ b/docs/modules/feo/feo/docs/requirements/component_requirements.rst
@@ -428,5 +428,5 @@ Error Handling for S-CORE v0.5
     If an activity fails in the shutdown function, the primary process shall shutdown all remaining activities
     in arbitrary sequence and terminate itself.
 
-.. needextend:: is_external == False and "feo/docs/requirements" in docname
+.. needextend:: c.this_doc() and is_external == False and "feo/docs/requirements" in docname
    :+tags: component_feo

--- a/docs/modules/os/docs/requirements/aou_req.rst
+++ b/docs/modules/os/docs/requirements/aou_req.rst
@@ -85,5 +85,5 @@ Generic Assumptions of Use
 
    Note3: Another example is mmap_peer which would allow accessing other processes memory if wrongly used.
 
-.. needextend:: is_external == False and "__os_" in id
+.. needextend:: c.this_doc() and is_external == False and "__os_" in id
    :+tags: operating_system


### PR DESCRIPTION
The future Docs-AS-Code releases will enforce that needextends directives can no longer adapt / change needs that are in a different document, therefore now c.this_doc() has to be in the future in every needextend.

This PR fixes this.

Tested with docs-as-code and process overwrite:

git_override(
    module_name = "score_docs_as_code",
    commit="eeaa863b5a323639593fe73721232ee3ce699681",
    remote="https://github.com/eclipse-score/docs-as-code"
)
git_override(
    module_name = "score_process",
    commit="76751ca540653121a32bbf4e3793b51c2895e32a",
    remote="https://github.com/eclipse-score/process_description"
)

