### PR TITLE
chore(devcontainer): align SCORE devcontainer versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.9.0
+FROM ghcr.io/eclipse-score/devcontainer:v1.9.2


### PR DESCRIPTION
<!-- repo-sync-policy: devcontainer.score-version-alignment -->
<!-- repo-sync-head: 37a686c715dbbd5b00689af035bb0aa3ced3b52f -->

## Policy

**`devcontainer.score-version-alignment`**

Keep the SCORE devcontainer image and direct score_devcontainer dependency on
the same version by upgrading only the older declaration.


## Why this repository?

This repository contains policy-managed legacy content in `.devcontainer/Dockerfile`. `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_devcontainer`.

## Changes

- `.devcontainer/Dockerfile`: align version from '1.9.0' to '1.9.2'
  - Keep the development image and its Bazel integration on a compatible version.



---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!WARNING]
> The tool producing this PR is in proof-of-concept stage. Review carefully.
