### PR TITLE
chore(devcontainer): standardize SCORE devcontainer integration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,4 +12,4 @@
 # *******************************************************************************
 
 # Use Dockerfile to get dependabot version bumps after new image is released
-FROM ghcr.io/eclipse-score/devcontainer:v1.9.0
+FROM ghcr.io/eclipse-score/devcontainer:v1.10.0

--- a/.devcontainer/run-tool
+++ b/.devcontainer/run-tool
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Unified entry point for running a CLI tool by name.
+# Inside a container the tool is expected on PATH; outside, it is resolved via Bazel.
+# See https://github.com/eclipse-score/devcontainer/tree/main/tools for further information.
+#
+# Do not modify this file. Its source of truth is managed by the
+# SCORE devcontainer standardization policy.
+
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+    echo "Usage: $0 <tool> [args...]" >&2
+    exit 2
+fi
+
+tool_name="$1"
+shift
+
+if { [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || [[ -d /devcontainer ]]; } &&
+  command -v "${tool_name}" >/dev/null 2>&1; then
+  exec "${tool_name}" "$@"
+elif command -v bazel >/dev/null 2>&1; then
+  exec bazel run "@score_devcontainer//tools:${tool_name}" -- "$@"
+else
+  echo "Could not run '${tool_name}': not available on PATH in a container, and bazel was not found." >&2
+  exit 127
+fi


### PR DESCRIPTION
<!-- repo-policy-sync-policy: devcontainer.score-standardization -->
<!-- repo-policy-sync-head: d93aaab528f39dc885a29e5370630daa150ca6c7 -->

## Policy

**`devcontainer.score-standardization`**

Keep the SCORE devcontainer image and direct dependency on the same version,
and provide the standard SCORE tool launcher.


## Why this repository?

This repository matches this policy because `.devcontainer/Dockerfile` matches this policy's file-content condition and `MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_devcontainer`.

## Changes

- `.devcontainer/run-tool`: add file
  - Provide the standard SCORE tool launcher in repositories using the SCORE devcontainer.
- `.devcontainer/Dockerfile`: align version from '1.9.0' to '1.10.0'
  - Keep the development image and its Bazel integration on a compatible version.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.
