### PR TITLE
correct tool table names, shortend headlines

### DIFF
--- a/docs/score_tools/tools_build_development/index.rst
+++ b/docs/score_tools/tools_build_development/index.rst
@@ -14,10 +14,10 @@
 
 .. _tools_build_development:
 
-Build & Development Tools Overview
-==================================
+Build & Development Tools
+=========================
 
-.. needtable:: Testing Frameworks List
+.. needtable:: Build & Development Tools List
    :tags: tool_management, tools_build_development
    :filter: "tool_management" in tags and "tools_build_development" in tags and type == "doc_tool" and is_external == False
    :style: table

--- a/docs/score_tools/tools_compiler/index.rst
+++ b/docs/score_tools/tools_compiler/index.rst
@@ -14,8 +14,8 @@
 
 .. _tools_compiler:
 
-Compiler Tools Overview
-=======================
+Compiler Tools
+==============
 
 .. needtable:: Compiler Tools List
    :tags: tool_management, tools_compiler

--- a/docs/score_tools/tools_documentation/index.rst
+++ b/docs/score_tools/tools_documentation/index.rst
@@ -14,8 +14,8 @@
 
 .. _tools_documentation:
 
-Documentation Tools Overview
-============================
+Documentation Tools
+===================
 
 .. needtable:: Documentation Tools List
    :tags: tool_management, tools_documentation

--- a/docs/score_tools/tools_static_analysis_code_quality/index.rst
+++ b/docs/score_tools/tools_static_analysis_code_quality/index.rst
@@ -14,8 +14,8 @@
 
 .. _tools_static_analysis_code_quality:
 
-Static Analysis & Code Quality Tools Overview
-=============================================
+Static Analysis & Code Quality Tools
+====================================
 
 .. needtable:: Static Analysis & Code Quality List
    :tags: tool_management, tools_static_analysis_code_quality

--- a/docs/score_tools/tools_testing_frameworks/index.rst
+++ b/docs/score_tools/tools_testing_frameworks/index.rst
@@ -14,8 +14,8 @@
 
 .. _tools_testing_frameworks:
 
-Testing Frameworks Tools Overview
-=================================
+Testing Frameworks Tools
+========================
 
 .. needtable:: Testing Frameworks List
    :tags: tool_management, tools_testing_frameworks

--- a/docs/score_tools/tools_vc_cicd/index.rst
+++ b/docs/score_tools/tools_vc_cicd/index.rst
@@ -14,10 +14,10 @@
 
 .. _tools_vc_cicd:
 
-Version Control & CI/CD Tools Overview
-======================================
+Version Control & CI/CD Tools
+=============================
 
-.. needtable:: Compiler Tools List
+.. needtable:: Verification & CI/CD Tools List
    :tags: tool_management, tools_vc_cicd
    :filter: "tool_management" in tags and "tools_vc_cicd" in tags and type == "doc_tool" and is_external == False
    :style: table


### PR DESCRIPTION
correctected some tool table names: 

- Build & Development Tools
- Verification & CI/CD Tools

shortend headline for visual purpose

- deleted Overview

