### PR TITLE
feat(docs): provide a bundle per feature

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,6 +62,60 @@ setup_starpls(
 )
 
 docs(
+    bundles = [
+        {
+            "bundle": "//docs/features/ai_platform:docs",
+            "mount_at": "features/ai_platform",
+        },
+        {
+            "bundle": "//docs/features/baselibs:docs",
+            "mount_at": "features/baselibs",
+        },
+        {
+            "bundle": "//docs/features/code_generation:docs",
+            "mount_at": "features/code_generation",
+        },
+        {
+            "bundle": "//docs/features/communication:docs",
+            "mount_at": "features/communication",
+        },
+        {
+            "bundle": "//docs/features/configuration:docs",
+            "mount_at": "features/configuration",
+        },
+        {
+            "bundle": "//docs/features/diagnostics:docs",
+            "mount_at": "features/diagnostics",
+        },
+        {
+            "bundle": "//docs/features/frameworks:docs",
+            "mount_at": "features/frameworks",
+        },
+        {
+            "bundle": "//docs/features/lifecycle:docs",
+            "mount_at": "features/lifecycle",
+        },
+        {
+            "bundle": "//docs/features/log_and_trace:docs",
+            "mount_at": "features/log_and_trace",
+        },
+        {
+            "bundle": "//docs/features/orchestration:docs",
+            "mount_at": "features/orchestration",
+        },
+        {
+            "bundle": "//docs/features/persistency:docs",
+            "mount_at": "features/persistency",
+        },
+        {
+            "bundle": "//docs/features/security_crypto:docs",
+            "mount_at": "features/security_crypto",
+        },
+        {
+            "bundle": "//docs/features/time:docs",
+            "mount_at": "features/time",
+        },
+    ],
     data = [
         "@score_process_description//:needs_json",
     ],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,13 @@ extensions = [
     "score_sphinx_bundle",
 ]
 
+# Feature documentation is provided by one Bazel bundle per feature and mounted
+# below ``features/``. Keep the live workspace sources out of the host
+# project's discovery so they are not registered twice by Sphinx.
+exclude_patterns = [
+    "features/*/**",
+]
+
 # Serve files from docs/_assets and load our own CSS overrides last so they win
 # over the styles shipped by the score_docs_as_code bundle.
 html_static_path = ["_assets"]

--- a/docs/features/ai_platform/BUILD
+++ b/docs/features/ai_platform/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/baselibs/BUILD
+++ b/docs/features/baselibs/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/code_generation/BUILD
+++ b/docs/features/code_generation/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/communication/BUILD
+++ b/docs/features/communication/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/configuration/BUILD
+++ b/docs/features/configuration/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/diagnostics/BUILD
+++ b/docs/features/diagnostics/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/frameworks/BUILD
+++ b/docs/features/frameworks/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -28,11 +28,10 @@ For further explanation see the `Building blocks concept <https://eclipse-score.
 
 The following features are defined:
 
+.. note: toctree will be filled by bazel build system, do not edit manually
+
 .. toctree::
    :maxdepth: 1
-   :glob:
-
-   */index
 
 Feature List
 ------------

--- a/docs/features/lifecycle/BUILD
+++ b/docs/features/lifecycle/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/log_and_trace/BUILD
+++ b/docs/features/log_and_trace/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/orchestration/BUILD
+++ b/docs/features/orchestration/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/persistency/BUILD
+++ b/docs/features/persistency/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/security_crypto/BUILD
+++ b/docs/features/security_crypto/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)

--- a/docs/features/time/BUILD
+++ b/docs/features/time/BUILD
@@ -1,0 +1,7 @@
+load("@score_docs_as_code//:docs.bzl", "docs_bundle")
+
+docs_bundle(
+    name = "docs",
+    source_dir = ".",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This will enable modules to select which features exactly they implement, thereby preventing accidental cross feature linking. Also this will enable modules to show the feature documentation directly in their documentation - if that is a usecase.

---

DO NOT MERGE

This requires docs-as-code >8.1.1
