### PR TITLE
chore: expand infrastructure maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,17 +5,17 @@
 
 # Note: last match wins
 
-# By Default reviews go to the infrastructure community, to address missing lines in this document.
-*                                     @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak
+# By Default reviews go to the infrastructure community and tech leads, to address missing lines in this document.
+*                                     @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak @nradakovic @antonkri @FScholPer @qor-lb @johannes-esr @anmittag
 
-# All special files go to infrastructure as well
-.*                                    @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak
+# All special files go to infrastructure
+.*                                    @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak @nradakovic @FScholPer
 
 .github/ISSUE_TEMPLATE/               @pahmann @masc2023 @aschemmel-tech @PandaeDo
 .github/CODEOWNERS                    @antonkri @FScholPer @qor-lb @johannes-esr @anmittag
 
 /docs/                                @pahmann @masc2023 @aschemmel-tech @PandaeDo
-/docs/conf.py                         @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak
+/docs/conf.py                         @AlexanderLanin @dcalavrezo-qorix @MaximilianSoerenPollak @a-zw
 /docs/contribute/                     @eclipse-score/automotive-score-committers
 # all architecture community members incl. FT leads
 /docs/features/                       @qor-lb @arsibo @ramceb @FScholPer @4og @LittleHuba @michaelsaborov @rmaddikery @pawelrutkaq @umaucher @sunildevda @lavrovvalera  @anmittag


### PR DESCRIPTION
Updated CODEOWNERS as pre-discussed with with current maintainers:

* `*` the generic case should be aligned with tech leads anyway
* `.*` @nradakovic and @FScholPer are constant members in the infrastructure community for 6++ months now, therefore we want to include them here as well
* `/docs/conf.py` @a-zw is a maintainer of `score_docs_as_code` and is therefore well suited to maintain the `conf.py` file in this repo as well.