### PR TITLE
chore(ci): align SCORE documentation workflows

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,12 +12,10 @@
 # *******************************************************************************
 
 name: Publish Documentation
-
 on:
   workflow_run:
-    workflows: ["Documentation"]
+    workflows: ["Documentation CI"]
     types: [completed]
-
 jobs:
   docs-publish:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,10 +12,12 @@
 # *******************************************************************************
 
 name: Publish Documentation
+
 on:
   workflow_run:
-    workflows: ["Documentation CI"]
+    workflows: ["Documentation"]
     types: [completed]
+
 jobs:
   docs-publish:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,18 +11,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-name: Documentation CI
+name: Documentation
+
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - main
-    tags:
-      - "v*"
-  release:
-    types: [published]
   merge_group:
     types: [checks_requested]
+  release:
+    types: [published]
+  workflow_dispatch:
+
 jobs:
   docs-build:
     uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@8d80e8df150cae21d53cbc8031d0f970648f7a67 # v0.0.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,23 +11,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-name: Documentation
-
-permissions:
-  contents: read
-
+name: Documentation CI
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
   push:
     branches:
-      - main # docs are built only on push to main branch, for feature branches there are PR builds
-  merge_group:
-    types: [checks_requested]
+      - main
+    tags:
+      - "v*"
   release:
     types: [published]
-  workflow_dispatch:
-
+  merge_group:
+    types: [checks_requested]
 jobs:
   docs-build:
     uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@8d80e8df150cae21d53cbc8031d0f970648f7a67 # v0.0.3


### PR DESCRIPTION
<!-- ----------------------------------------------------------------------------
  Copyright (c) 2026 Contributors to the Eclipse Foundation

  See the NOTICE file(s) distributed with this work for additional
  information regarding copyright ownership.

  This program and the accompanying materials are made available under the
  terms of the Apache License Version 2.0 which is available at
  https://www.apache.org/licenses/LICENSE-2.0

  SPDX-License-Identifier: Apache-2.0
----------------------------------------------------------------------------- -->

## Policy

**`score-docs-workflow-alignment`**

Use the shared SCORE documentation build and publish workflows as documented
by cicd-workflows. Keep repository-specific workflow refs when they are at
least the policy baseline or cannot be safely ordered.


## Why this repository?

This repository matches this policy because `.github/workflows/docs.yml` matches this policy's file-content condition.

## Changes

- `.github/workflows/docs.yml`: synchronize contents
  - Use the documented unprivileged documentation build workflow.
- `.github/workflows/docs-publish.yml`: synchronize contents
  - Publish only successful documentation artifacts with the documented workflow.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.

<!-- repo-policy-sync-policy: score-docs-workflow-alignment -->
<!-- repo-policy-sync-head: 98e3a70d78fbe063176c0e6bcf0cd701128519ca -->
