### PR TITLE
fix: keep software verification link mount-relative

### DIFF
--- a/docs/contribute/development/rust/coding_guidelines.rst
+++ b/docs/contribute/development/rust/coding_guidelines.rst
@@ -263,7 +263,7 @@ settings are maintained centrally in the
 `score_rust_policies repository <https://github.com/eclipse-score/score_rust_policies>`_:
 
 CodeQL is handled separately from this repository; see *Rust Tooling: CodeQL*
-above and :doc:`/platform_management_plan/software_verification`.
+above and :doc:`../../../platform_management_plan/software_verification`.
 
 * `Practical baseline (relaxed) <https://github.com/eclipse-score/score_rust_policies/blob/main/clippy/relaxed/Cargo.toml>`_ —
   suitable for general SCORE components.


### PR DESCRIPTION
## Summary

Replace the absolute `:doc:` target in the Rust coding guidelines with a relative target. This keeps the link valid when the Platform documentation bundle is mounted below a consumer-specific prefix.

We need this fix for 0.9 S-CORE Release.