### PR TITLE
Fix broken module safety manual links in platform safety manual

### DIFF
--- a/docs/safety/platform_safety_manual.rst
+++ b/docs/safety/platform_safety_manual.rst
@@ -134,12 +134,12 @@ References
 
 :need:`doc__platform_handbook`
 
-`Baselibs Safety Manual <https://eclipse-score.github.io/score/main/modules/baselibs/docs/manual/safety_manual.html>`_
+`Baselibs Safety Manual <https://eclipse-score.github.io/baselibs/main/module/manuals/safety_manual.html>`_
 
 `IPC Safety Manual <https://eclipse-score.github.io/score/main/modules/communication/docs/manual/safety_manual.html>`_
 
 `FEO Safety Manual <https://eclipse-score.github.io/score/main/modules/feo/docs/manual/safety_manual.html>`_
 
-`KVS Safety Manual <https://eclipse-score.github.io/persistency/main/docs/manual/safety_manual.html>`_
+`KVS Safety Manual <https://eclipse-score.github.io/persistency/main/module/manuals/safety_manual.html>`_
 
 `Orchestrator Safety Manual <https://eclipse-score.github.io/score/main/modules/orchestrator/docs/manual/safety_manual.html>`_


### PR DESCRIPTION
# Bugfix

> [!IMPORTANT]
> Use this template only for bugfixes that do not influence topics covered by change requests or improvements.

## Description

The references section of the platform safety manual links to the Baselibs safety manual under `score/main/modules/baselibs/...`, which is not published (404). Baselibs publishes its documentation in its own GitHub Pages.

This PR updates the link to https://eclipse-score.github.io/baselibs/main/module/manuals/safety_manual.html.

The adjacent KVS (persistency) safety manual link in the same block was broken for the same reason (`persistency/main/docs/manual/...` -> 404), so it is updated to https://eclipse-score.github.io/persistency/main/module/manuals/safety_manual.html as well.

All five module safety manual links in the references section now return HTTP 200 (verified with curl).

## Related ticket

closes #3146 (bugfix ticket)