### PR TITLE
Fix broken scrample link in the user's guide

### DIFF
--- a/docs/users_guide/whats_next/index.rst
+++ b/docs/users_guide/whats_next/index.rst
@@ -28,7 +28,7 @@ Becoming a contributor
 #. **Read the User's Guide** — Work through the complete :ref:`users_guide` from start to finish to
    build a solid foundation of S-CORE knowledge.
 
-#. **Start the S-CORE test application "scrample"** — Run `scrample <https://github.com/eclipse-score/scrample/tree/v0.1.2-simple-app>`_ locally to experience the
+#. **Start the S-CORE test application "scrample"** — Run `scrample <https://github.com/eclipse-score/scrample/tree/v0.1.1>`_ locally to experience the
    full development loop (build, test, CI/CD) on a real, self-contained project.
 
 #. **Implement an open issue and create a pull request** — Pick up an open issue in any S-CORE


### PR DESCRIPTION
# Bugfix

> [!IMPORTANT]
> Use this template only for bugfixes that do not influence topics covered by change requests or improvements.

## Description

The "What's next" page of the user's guide links to the scrample tag `v0.1.2-simple-app`, which does not exist (404). As suggested in the issue, the link now points to the latest existing release `v0.1.1`.

Note: a fixed tag will go stale again with the next scrample release. If preferred, the link could instead point to https://github.com/eclipse-score/scrample/releases/latest, which always resolves to the newest release. Happy to change it.

## Related ticket

closes #3145 (bugfix ticket)