### PR TITLE
gitlint: Add rebase hint for older non-compliant commits

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -34,9 +34,12 @@ runs:
       if ! gitlint --commits origin/${{ inputs.base-branch }}..HEAD; then \
         echo -e "\nWARNING: Your commit message does not follow the required format." && \
         echo "Formatting rules: https://eclipse-score.github.io/score/main/contribute/general/git.html" && \
-        echo -e "To fix your commit message, run:\n" && \
+        echo -e "\nIf only the most recent commit is affected, run:\n" && \
         echo " git commit --amend" && \
-        echo "Then update your commit (fix gitlint warnings). Finally, force-push:" && \
+        echo -e "\nIf an older commit is affected, start an interactive rebase and" && \
+        echo -e "change 'pick' to 'reword' for every commit reported above:\n" && \
+        echo " git rebase -i origin/${{ inputs.base-branch }}" && \
+        echo -e "\nAfter updating the commit messages, force-push:\n" && \
         echo " git push --force-with-lease" && \
         exit 1; \
       fi


### PR DESCRIPTION
# Bugfix

## Description

The `check-commit-messages` job prints a hint that only suggests `git commit --amend`. That command rewrites the most recent commit, so it does not help when an older commit on the branch is the one violating the rules - which is exactly the case reported in #3057, where two commits were flagged and the offending one was not at `HEAD`.

This adds an interactive rebase hint next to the existing amend hint, so both cases are covered.

The rebase hint points at `origin/<base-branch>`, the same revision the check compares against (`gitlint --commits origin/<base-branch>..HEAD`). That way the range offered for rewriting is exactly the range that was verified, and contributors do not have to work out a commit hash or an off-by-one `~1` themselves.

Example output when the check fails:

```
WARNING: Your commit message does not follow the required format.
Formatting rules: https://eclipse-score.github.io/score/main/contribute/general/git.html

If only the most recent commit is affected, run:

 git commit --amend

If an older commit is affected, start an interactive rebase and
change 'pick' to 'reword' for every commit reported above:

 git rebase -i origin/main

After updating the commit messages, force-push:

 git push --force-with-lease
```

Note: the issue suggests `git rebase -i <commit-hash>`. Since `git rebase -i <commit>` starts *after* the named commit, that form would not make the reported commit editable; `origin/<base-branch>` avoids the pitfall and needs no hash lookup.

Verified locally: the action YAML parses, the extracted script passes `sh -n`, and the failure branch produces the output shown above.

## Related ticket

closes #3057 (bugfix ticket)